### PR TITLE
feat: add more community integrations

### DIFF
--- a/pages/overview/integrations.mdx
+++ b/pages/overview/integrations.mdx
@@ -34,6 +34,13 @@ In the following table you can see the _state_ of planned and released packages 
 | `@auth/astro`          | Planned, [help needed](#help-needed).                                                                                                                                                  |
 | `@auth/nuxt`           | Planned, [help needed](#help-needed). Community packages: [`@sidebase/nuxt-auth`](https://github.com/sidebase/nuxt-auth), [`@hebilicious/authjs-nuxt`](https://authjs-nuxt.pages.dev/) |
 
+### Community Integrations
+
+| Client   | More Info                                                                                            |
+| -------- | ---------------------------------------------------------------------------------------------------- |
+| `hono`   | Hono [Auth.js middleware](https://github.com/honojs/middleware/tree/main/packages/auth-js).          |
+| `rakkas` | Rakkasjs [Auth.js Integration Example](https://github.com/rakkasjs/rakkasjs/tree/main/examples/auth) |
+
 ### Help needed
 
 In case you are a maintainer of a package that uses `@auth/core`, feel free to [reach out to Balázs](https://twitter.com/balazsorban44), if you want to collaborate on making it an official package, maintained in our repository. If you are interested in bringing `@auth/core` support to your favorite framework, we would love to hear from you!

--- a/pages/overview/integrations.mdx
+++ b/pages/overview/integrations.mdx
@@ -36,9 +36,9 @@ In the following table you can see the _state_ of planned and released packages 
 
 ### Community Integrations
 
-| Client  | More Info                                                                                   |
+| Client  | Links                                                                                       |
 | ------- | ------------------------------------------------------------------------------------------- |
-| Hono.js | [Auth.js middleware](https://github.com/honojs/middleware/tree/main/packages/auth-js).      |
+| Hono.js | [Auth.js middleware](https://github.com/honojs/middleware/tree/main/packages/auth-js)       |
 | Rakkas  | [Auth.js Integration Example](https://github.com/rakkasjs/rakkasjs/tree/main/examples/auth) |
 
 ### Help needed

--- a/pages/overview/integrations.mdx
+++ b/pages/overview/integrations.mdx
@@ -36,10 +36,10 @@ In the following table you can see the _state_ of planned and released packages 
 
 ### Community Integrations
 
-| Client   | More Info                                                                                            |
-| -------- | ---------------------------------------------------------------------------------------------------- |
-| `hono`   | Hono [Auth.js middleware](https://github.com/honojs/middleware/tree/main/packages/auth-js).          |
-| `rakkas` | Rakkasjs [Auth.js Integration Example](https://github.com/rakkasjs/rakkasjs/tree/main/examples/auth) |
+| Client  | More Info                                                                                   |
+| ------- | ------------------------------------------------------------------------------------------- |
+| Hono.js | [Auth.js middleware](https://github.com/honojs/middleware/tree/main/packages/auth-js).      |
+| Rakkas  | [Auth.js Integration Example](https://github.com/rakkasjs/rakkasjs/tree/main/examples/auth) |
 
 ### Help needed
 


### PR DESCRIPTION
- What do we think about an additional table for actually-external integrations/clients?
- Add `Hono` and `Rakkasjs` community integrations under a new "Community Integrations" table.