### PR TITLE
feat: add deep-linking and localStorage support for code tabs

### DIFF
--- a/components/Code/index.tsx
+++ b/components/Code/index.tsx
@@ -47,7 +47,7 @@ export function Code({ children }: ChildrenProps) {
     if (!tab) return 0;
     const foundKey = Object.values(renderedFrameworks).findIndex(
       // TODO: Maybe slugify for better results?
-      (f) => f.toLowerCase().replace(".", "") === tab
+      (f) => f.toLowerCase() === tab.toLowerCase()
     );
     return foundKey;
   };

--- a/components/Code/index.tsx
+++ b/components/Code/index.tsx
@@ -30,6 +30,9 @@ const allFrameworks = {
 
 export function Code({ children }: ChildrenProps) {
   const router = useRouter();
+  const {
+    query: { tab },
+  } = router;
   const childs = Children.toArray(children);
   const { project } = useThemeConfig();
 
@@ -40,8 +43,20 @@ export function Code({ children }: ChildrenProps) {
 
   const renderedFrameworks = withNextJsPages ? allFrameworks : baseFrameworks;
 
+  const findIndexOfTab = (tab: string): number => {
+    if (!tab) return 0;
+    const foundKey = Object.values(renderedFrameworks).findIndex(
+      // TODO: Maybe slugify for better results?
+      (f) => f.toLowerCase().replace(".", "") === tab
+    );
+    return foundKey;
+  };
+
   return (
-    <Tabs items={Object.values(renderedFrameworks)}>
+    <Tabs
+      items={Object.values(renderedFrameworks)}
+      selectedIndex={findIndexOfTab(tab as string)}
+    >
       {Object.keys(renderedFrameworks).map((f) => {
         // @ts-expect-error: Hacky dynamic child wrangling
         const child = childs.find((c) => c?.type?.name === f);
@@ -51,7 +66,7 @@ export function Code({ children }: ChildrenProps) {
           child
         ) : (
           <Tabs.Tab key={f}>
-            <p className="p-6 font-semibold rounded-lg bg-slate-100">
+            <p className="p-6 font-semibold rounded-lg bg-slate-100 dark:bg-neutral-950">
               {renderedFrameworks[f]} not documented yet. Help us by
               contributing{" "}
               <a

--- a/components/Code/index.tsx
+++ b/components/Code/index.tsx
@@ -40,7 +40,7 @@ const findTabIndex = (frameworks: Record<string, string>, tab: string) => {
 export function Code({ children }: ChildrenProps) {
   const router = useRouter();
   const {
-    query: { tab },
+    query: { framework },
   } = router;
   const childs = Children.toArray(children);
   const { project } = useThemeConfig();
@@ -57,16 +57,16 @@ export function Code({ children }: ChildrenProps) {
     const savedTabPreference = Number(
       window.localStorage.getItem(AUTHJS_TAB_KEY)
     );
-    if (tab) {
+    if (framework) {
       window.localStorage.setItem(
         AUTHJS_TAB_KEY,
-        String(findTabIndex(renderedFrameworks, tab as string))
+        String(findTabIndex(renderedFrameworks, framework as string))
       );
-      setTabIndex(findTabIndex(renderedFrameworks, tab as string));
+      setTabIndex(findTabIndex(renderedFrameworks, framework as string));
     } else if (savedTabPreference) {
       setTabIndex(savedTabPreference);
     }
-  }, [tab, renderedFrameworks]);
+  }, [framework, renderedFrameworks]);
 
   return (
     <Tabs

--- a/components/DemoCards/index.tsx
+++ b/components/DemoCards/index.tsx
@@ -78,6 +78,7 @@ export function DemoCards() {
             </Link>
             <a
               href={href}
+              rel="noreferrer"
               target="_blank"
               className="flex justify-center p-2 w-full text-sm rounded-md bg-slate-100 dark:bg-neutral-900"
             >

--- a/components/DemoCards/index.tsx
+++ b/components/DemoCards/index.tsx
@@ -62,7 +62,7 @@ export function DemoCards() {
         const content = (
           <div className="flex flex-col gap-2" key={name}>
             <Link
-              href={`/overview/installation?tab=${name.toLowerCase()}`}
+              href={`/overview/installation?framework=${name.toLowerCase()}`}
               className="flex relative flex-col flex-wrap justify-between items-center p-4 w-28 bg-white rounded-lg border border-solid shadow-lg border-slate-200 dark:border-neutral-800 dark:bg-neutral-900"
             >
               <img alt={name} src={img} width={logoWidth} />

--- a/components/DemoCards/index.tsx
+++ b/components/DemoCards/index.tsx
@@ -59,7 +59,6 @@ export function DemoCards() {
           ),
         },
       ].map(({ href, name, img, logoWidth, wip, label }) => {
-        console.log({ href, name, img, logoWidth, wip, label });
         const content = (
           <Link
             href={`/overview/installation?tab=${name.toLowerCase()}`}

--- a/components/DemoCards/index.tsx
+++ b/components/DemoCards/index.tsx
@@ -60,22 +60,30 @@ export function DemoCards() {
         },
       ].map(({ href, name, img, logoWidth, wip, label }) => {
         const content = (
-          <Link
-            href={`/overview/installation?tab=${name.toLowerCase()}`}
-            key={name}
-            className="flex relative flex-col flex-wrap justify-between items-center p-4 w-28 bg-white rounded-lg border border-solid shadow-lg border-slate-200 dark:border-neutral-800 dark:bg-neutral-900"
-          >
-            <img alt={name} src={img} width={logoWidth} />
-            <div className="mt-3 text-sm">{name}</div>
-            {wip ? (
-              <div
-                className="absolute py-1 px-3 text-sm font-semibold text-black bg-amber-300 rounded-full shadow-sm"
-                style={{ right: "-30px", top: "-15px" }}
-              >
-                Beta
-              </div>
-            ) : null}
-          </Link>
+          <div className="flex flex-col gap-2" key={name}>
+            <Link
+              href={`/overview/installation?tab=${name.toLowerCase()}`}
+              className="flex relative flex-col flex-wrap justify-between items-center p-4 w-28 bg-white rounded-lg border border-solid shadow-lg border-slate-200 dark:border-neutral-800 dark:bg-neutral-900"
+            >
+              <img alt={name} src={img} width={logoWidth} />
+              <div className="mt-3 text-sm">{name}</div>
+              {wip ? (
+                <div
+                  className="absolute py-1 px-3 text-sm font-semibold text-black bg-amber-300 rounded-full shadow-sm"
+                  style={{ right: "-30px", top: "-15px" }}
+                >
+                  Beta
+                </div>
+              ) : null}
+            </Link>
+            <a
+              href={href}
+              target="_blank"
+              className="flex justify-center p-2 w-full text-sm rounded-md bg-slate-100 dark:bg-neutral-900"
+            >
+              View Demo
+            </a>
+          </div>
         );
 
         return wip ? (

--- a/components/DemoCards/index.tsx
+++ b/components/DemoCards/index.tsx
@@ -29,21 +29,6 @@ export function DemoCards() {
           ),
         },
         {
-          href: "https://auth-solid.vercel.app/",
-          img: "/img/etc/solidstart.svg",
-          name: "SolidStart",
-          logoWidth: "45",
-          wip: true,
-          label: (
-            <>
-              Officially supported but not documented. Help us{" "}
-              <a href="https://github.com/nextauthjs/next-auth/issues">
-                document it.
-              </a>
-            </>
-          ),
-        },
-        {
           href: "https://authjs-express-dev-app.onrender.com/",
           img: "/img/etc/express.svg",
           name: "Express",
@@ -58,13 +43,28 @@ export function DemoCards() {
             </>
           ),
         },
+        {
+          href: "https://auth-solid.vercel.app/",
+          img: "/img/etc/solidstart.svg",
+          name: "SolidStart",
+          logoWidth: "45",
+          wip: true,
+          label: (
+            <>
+              Officially supported but not documented. Help us{" "}
+              <a href="https://github.com/nextauthjs/next-auth/issues">
+                document it.
+              </a>
+            </>
+          ),
+        },
       ].map(({ href, name, img, logoWidth, wip, label }) => {
+        console.log({ href, name, img, logoWidth, wip, label });
         const content = (
           <Link
-            href={href}
+            href={`/overview/installation?tab=${name.toLowerCase()}`}
             key={name}
             className="flex relative flex-col flex-wrap justify-between items-center p-4 w-28 bg-white rounded-lg border border-solid shadow-lg border-slate-200 dark:border-neutral-800 dark:bg-neutral-900"
-            target="_blank"
           >
             <img alt={name} src={img} width={logoWidth} />
             <div className="mt-3 text-sm">{name}</div>

--- a/components/DemoCards/index.tsx
+++ b/components/DemoCards/index.tsx
@@ -21,7 +21,7 @@ export function DemoCards() {
           wip: true,
           label: (
             <>
-              Officially supported but not documented. Help us{" "}
+              Officially supported but not fully documented. Help us{" "}
               <a href="https://github.com/nextauthjs/next-auth/issues">
                 document it.
               </a>
@@ -36,7 +36,7 @@ export function DemoCards() {
           wip: true,
           label: (
             <>
-              Officially supported but not documented. Help us{" "}
+              Officially supported but not fully documented. Help us{" "}
               <a href="https://github.com/nextauthjs/next-auth/issues">
                 document it.
               </a>
@@ -51,7 +51,7 @@ export function DemoCards() {
           wip: true,
           label: (
             <>
-              Officially supported but not documented. Help us{" "}
+              Officially supported but not fully documented. Help us{" "}
               <a href="https://github.com/nextauthjs/next-auth/issues">
                 document it.
               </a>


### PR DESCRIPTION
- Use built-in `storageKey` prop on `Tabs` to sync between one another
- Sync that with a deep link via query param (click on one of the framework btns from the screenshots below, for example)
- Added "View Demo" btns below the main framework buttons

![image](https://github.com/ubbe-xyz/nextra-docs/assets/7415984/92bb6f6e-da5a-4dea-ab49-19620e41df49)

![image](https://github.com/ubbe-xyz/nextra-docs/assets/7415984/0acb0af6-a344-478d-b91a-dda92227f9c2)

## Notes

- `?framework=sveltekit` deep links to the framework selection tabs
- `?tab=passwordless` deep links to the "rich tabs" (with icons)

