### PR TITLE
fix: force tabs to be mounted upon initial SSR

### DIFF
--- a/components/RichTabs/index.tsx
+++ b/components/RichTabs/index.tsx
@@ -44,6 +44,7 @@ RichTabs.Content = function TabsContent({
 }: TabsContentProps & { orientation?: TabsProps["orientation"] }) {
   return (
     <Content
+      forceMount
       {...rest}
       className={cx(
         "border border-solid dark:border-neutral-800 border-slate-200 shadow-sm",


### PR DESCRIPTION
- Add `forceMount` option to force all tab content components to be mounted upon initial rendering so that they're included in the first SSR reponse from the server. That way crawlers and such can see the content as well