### PR TITLE
feat: add ask API

### DIFF
--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -98,3 +98,5 @@ function assertQuery(value: unknown): asserts value is Query {
   if (typeof value.query !== "string")
     throw new TypeError("Query must be a string");
 }
+
+export const runtime = "edge";

--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -1,0 +1,22 @@
+interface Query {
+  query: string;
+}
+
+export async function POST(request: Request): Promise<Response | void> {
+  try {
+    const body: unknown = await request.json();
+    assertBody(body);
+
+    return new Response(body.query);
+  } catch (error) {
+    return new Response(error, { status: 500 });
+  }
+}
+
+function assertBody(body: unknown): asserts body is Query {
+  if (!body) throw new TypeError("Missing body");
+  if (typeof body !== "object") throw new TypeError("Body must be an object");
+  if (!("query" in body)) throw new TypeError("Missing query in body");
+  if (typeof body.query !== "string")
+    throw new TypeError("Query must be a string");
+}

--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -1,25 +1,100 @@
-interface Query {
-  query: string;
+interface Result {
+  data: {
+    search: {
+      searchHits: {
+        id: string;
+        preview: string;
+        title: string;
+        url: string;
+      }[];
+    };
+  };
+  errors?: {
+    message: string;
+  }[];
 }
 
 export async function POST(request: Request): Promise<Response | void> {
   try {
-    const body: unknown = await request.json();
-    assertBody(body);
+    const config = {
+      apiKey: process.env.INKEEP_API_KEY,
+      orgId: process.env.INKEEP_ORG_ID,
+      integrationId: process.env.INKEEP_INTEGRATION_ID,
+    };
+    assertConfig(config);
 
-    // TODO: Retrieve answer
-    // and format for sending back to the CLI
+    const query: unknown = await request.json();
+    assertQuery(query);
 
-    return new Response(body.query);
+    const response = await fetch("https://api.inkeep.com/graphql", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${config.apiKey}`,
+      },
+      body: JSON.stringify({
+        query: `query {
+          search(
+            searchInput: {
+              searchQuery: "${query.query}",
+              organizationId: "${config.orgId}",
+              integrationId: "${config.integrationId}",
+              filters: {},
+              searchMode: AUTO
+            }
+          ) {
+            searchHits {
+              id
+              preview
+              title
+              url
+            }
+          }
+        }`,
+      }),
+    });
+
+    const result: Result = await response.json();
+
+    if (result.errors) {
+      // eslint-disable-next-line no-console
+      console.error(result.errors);
+      throw new Error("Something went wrong, contact us.");
+    }
+
+    // TODO: Format response
+
+    return new Response("TODO");
   } catch (error) {
     return new Response(error, { status: 500 });
   }
 }
 
-function assertBody(body: unknown): asserts body is Query {
-  if (!body) throw new TypeError("Missing body");
-  if (typeof body !== "object") throw new TypeError("Body must be an object");
-  if (!("query" in body)) throw new TypeError("Missing query in body");
-  if (typeof body.query !== "string")
+interface APIConfig extends Record<string, string> {
+  apiKey: string;
+  orgId: string;
+  integrationId: string;
+}
+
+function assertConfig(
+  config: Record<string, string | undefined>
+): asserts config is APIConfig {
+  if (!config.apiKey) throw new TypeError("Missing apiKey");
+  if (!config.orgId) throw new TypeError("Missing orgId");
+  if (!config.integrationId) throw new TypeError("Missing integrationId");
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+interface Query {
+  query: string;
+}
+
+function assertQuery(value: unknown): asserts value is Query {
+  if (!isObject(value)) throw new TypeError("Body must be an object");
+  if (!("query" in value)) throw new TypeError("Missing query in body");
+  if (typeof value.query !== "string")
     throw new TypeError("Query must be a string");
 }

--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -7,6 +7,9 @@ export async function POST(request: Request): Promise<Response | void> {
     const body: unknown = await request.json();
     assertBody(body);
 
+    // TODO: Retrieve answer
+    // and format for sending back to the CLI
+
     return new Response(body.query);
   } catch (error) {
     return new Response(error, { status: 500 });

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,14 +29,21 @@
       "@/data/*": [
         "pages/data/*"
       ]
-    }
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": true
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
     "tailwind.config.js",
-    "pages/_meta.js"
+    "pages/_meta.js",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Used together with `npx auth ask`. We proxy the search through our API so we don't have to ember any API_KEY into the distributed CLI.

See also: https://github.com/nextauthjs/auth-cli/pull/3