### PR TITLE
feat: add AI btn

### DIFF
--- a/components/InkeepSearch/index.tsx
+++ b/components/InkeepSearch/index.tsx
@@ -10,15 +10,13 @@ export function InkeepTrigger() {
     setIsOpen(false);
   }, []);
 
-  const { baseSettings, aiChatSettings, searchSettings, modalSettings } =
-    useInkeepSettings();
+  const { baseSettings, aiChatSettings, modalSettings } = useInkeepSettings();
 
   const inkeepCustomTriggerProps: InkeepCustomTriggerProps = {
     isOpen,
     onClose: handleClose,
     baseSettings,
     aiChatSettings,
-    searchSettings,
     modalSettings,
   };
 

--- a/components/InkeepSearch/index.tsx
+++ b/components/InkeepSearch/index.tsx
@@ -1,13 +1,12 @@
-import React, { useState, useCallback } from "react";
+import { useState, useCallback } from "react";
 import { InkeepCustomTrigger, InkeepCustomTriggerProps } from "@inkeep/widgets";
 import useInkeepSettings from "@/utils/useInkeepSettings";
 import { Sparkle } from "@phosphor-icons/react";
 
-export const InkeepTrigger: React.FC = () => {
+export function InkeepTrigger() {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleClose = useCallback(() => {
-    console.log("Modal closed");
     setIsOpen(false);
   }, []);
 
@@ -35,4 +34,4 @@ export const InkeepTrigger: React.FC = () => {
       <InkeepCustomTrigger {...inkeepCustomTriggerProps} />
     </div>
   );
-};
+}

--- a/components/InkeepSearch/index.tsx
+++ b/components/InkeepSearch/index.tsx
@@ -1,0 +1,38 @@
+import React, { useState, useCallback } from "react";
+import { InkeepCustomTrigger, InkeepCustomTriggerProps } from "@inkeep/widgets";
+import useInkeepSettings from "@/utils/useInkeepSettings";
+import { Sparkle } from "@phosphor-icons/react";
+
+export const InkeepTrigger: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleClose = useCallback(() => {
+    console.log("Modal closed");
+    setIsOpen(false);
+  }, []);
+
+  const { baseSettings, aiChatSettings, searchSettings, modalSettings } =
+    useInkeepSettings();
+
+  const inkeepCustomTriggerProps: InkeepCustomTriggerProps = {
+    isOpen,
+    onClose: handleClose,
+    baseSettings,
+    aiChatSettings,
+    searchSettings,
+    modalSettings,
+  };
+
+  return (
+    <div>
+      <button
+        className="flex gap-2 items-center py-1.5 px-3 text-base leading-tight text-gray-800 rounded-lg transition-colors md:text-sm dark:text-gray-200 bg-black/[.05] dark:bg-gray-50/10"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <Sparkle size={18} />
+        Ask AI
+      </button>
+      <InkeepCustomTrigger {...inkeepCustomTriggerProps} />
+    </div>
+  );
+};

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/ubbe-xyz/nextra-docs#readme",
   "dependencies": {
     "@ark-ui/react": "^1.1.0",
+    "@inkeep/widgets": "^0.2.258",
     "@next/third-parties": "^14.1.0",
     "@phosphor-icons/react": "^2.0.15",
     "@radix-ui/react-tabs": "^1.0.4",

--- a/pages/global.css
+++ b/pages/global.css
@@ -122,13 +122,18 @@ details > *:not(summary) {
 .github-counter {
   position: absolute;
   color: #000;
-  top: -25px;
-  right: -5px;
+  top: 11px;
+  right: -18px;
   font-size: 9px;
   background-color: #ccc;
   padding: 2px 5px;
   border-radius: 10px;
   z-index: -1;
+  pointer-events: none;
+}
+
+div.nextra-search + a {
+  display: none;
 }
 
 html[data-theme="dark"] .github-counter {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@ark-ui/react':
     specifier: ^1.1.0
     version: 1.1.0(@internationalized/date@3.5.0)(react-dom@18.2.0)(react@18.2.0)
+  '@inkeep/widgets':
+    specifier: ^0.2.258
+    version: 0.2.258(@internationalized/date@3.5.0)(@types/react@18.2.46)(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
   '@next/third-parties':
     specifier: ^14.1.0
     version: 14.1.0(next@14.0.4)(react@18.2.0)
@@ -95,6 +98,81 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /@apollo/client@3.8.10(graphql-ws@5.14.3)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-p/22RZ8ehHyvySnC20EHPPe0gdu8Xp6ZCiXOfdEe1ZORw5cUteD/TLc66tfKv8qu8NLIfbiWoa+6s70XnKvxqg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql-ws: ^5.5.5
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      subscriptions-transport-ws: ^0.9.0 || ^0.11.0
+    peerDependenciesMeta:
+      graphql-ws:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      subscriptions-transport-ws:
+        optional: true
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.1)
+      '@wry/equality': 0.5.7
+      '@wry/trie': 0.5.0
+      graphql: 16.8.1
+      graphql-tag: 2.12.6(graphql@16.8.1)
+      graphql-ws: 5.14.3(graphql@16.8.1)
+      hoist-non-react-statics: 3.3.2
+      optimism: 0.18.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      response-iterator: 0.2.6
+      symbol-observable: 4.0.0
+      ts-invariant: 0.10.3
+      tslib: 2.6.2
+      zen-observable-ts: 1.2.5
+    dev: false
+
+  /@ark-ui/anatomy@0.1.0(@internationalized/date@3.5.0):
+    resolution: {integrity: sha512-ZIBtFlmcIVAzm4OUh122XngdgTp++OvtqFmPskzFtyJaODFZvytYYZeP6g1XCxHmkLve2ci+MY76U7iMuk+wAQ==}
+    dependencies:
+      '@zag-js/accordion': 0.20.0
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/avatar': 0.20.0
+      '@zag-js/carousel': 0.20.0
+      '@zag-js/checkbox': 0.20.0
+      '@zag-js/color-picker': 0.20.0
+      '@zag-js/color-utils': 0.20.0
+      '@zag-js/combobox': 0.20.0
+      '@zag-js/date-picker': 0.20.0
+      '@zag-js/date-utils': 0.20.0(@internationalized/date@3.5.0)
+      '@zag-js/dialog': 0.20.0
+      '@zag-js/editable': 0.20.0
+      '@zag-js/hover-card': 0.20.0
+      '@zag-js/menu': 0.20.0
+      '@zag-js/number-input': 0.20.0
+      '@zag-js/pagination': 0.20.0
+      '@zag-js/pin-input': 0.20.0
+      '@zag-js/popover': 0.20.0
+      '@zag-js/presence': 0.20.0
+      '@zag-js/pressable': 0.20.0
+      '@zag-js/radio-group': 0.20.0
+      '@zag-js/range-slider': 0.20.0
+      '@zag-js/rating-group': 0.20.0
+      '@zag-js/select': 0.20.0
+      '@zag-js/slider': 0.20.0
+      '@zag-js/splitter': 0.20.0
+      '@zag-js/switch': 0.20.0
+      '@zag-js/tabs': 0.20.0
+      '@zag-js/tags-input': 0.20.0
+      '@zag-js/toast': 0.20.0
+      '@zag-js/toggle-group': 0.20.0
+      '@zag-js/tooltip': 0.20.0
+    transitivePeerDependencies:
+      - '@internationalized/date'
+    dev: false
+
   /@ark-ui/anatomy@1.1.0(@internationalized/date@3.5.0):
     resolution: {integrity: sha512-ClB8qUt1ZYLcTrLHA7zVgGPTmz4RaJvDEQdz0PozWYjfys55n/QRMLP9/bu4tLhAH7V3QU0Kllxo4iT4/Iz+lQ==}
     dependencies:
@@ -129,6 +207,53 @@ packages:
       '@zag-js/toast': 0.30.0
       '@zag-js/toggle-group': 0.30.0
       '@zag-js/tooltip': 0.30.0
+    transitivePeerDependencies:
+      - '@internationalized/date'
+    dev: false
+
+  /@ark-ui/react@0.15.0(@internationalized/date@3.5.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Y4vkTy969pAcWPKFvgHNoAJ0cv2VoES43/CMeWmJRUuT6WTSE8WcLbOzEQoZ6vuFcOXQh65Dk5le1CVXrVC2cQ==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+    dependencies:
+      '@zag-js/accordion': 0.19.1
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/avatar': 0.19.1
+      '@zag-js/carousel': 0.19.1
+      '@zag-js/checkbox': 0.19.1
+      '@zag-js/color-picker': 0.19.1
+      '@zag-js/color-utils': 0.19.1
+      '@zag-js/combobox': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/date-picker': 0.19.1
+      '@zag-js/date-utils': 0.19.1(@internationalized/date@3.5.0)
+      '@zag-js/dialog': 0.19.1
+      '@zag-js/editable': 0.19.1
+      '@zag-js/hover-card': 0.19.1
+      '@zag-js/menu': 0.19.1
+      '@zag-js/number-input': 0.19.1
+      '@zag-js/pagination': 0.19.1
+      '@zag-js/pin-input': 0.19.1
+      '@zag-js/popover': 0.19.1
+      '@zag-js/presence': 0.19.1
+      '@zag-js/pressable': 0.19.1
+      '@zag-js/radio-group': 0.19.1
+      '@zag-js/range-slider': 0.19.1
+      '@zag-js/rating-group': 0.19.1
+      '@zag-js/react': 0.19.1(react-dom@18.2.0)(react@18.2.0)
+      '@zag-js/select': 0.19.1
+      '@zag-js/slider': 0.19.1
+      '@zag-js/splitter': 0.19.1
+      '@zag-js/switch': 0.19.1
+      '@zag-js/tabs': 0.19.1
+      '@zag-js/tags-input': 0.19.1
+      '@zag-js/toast': 0.19.1
+      '@zag-js/toggle-group': 0.19.1
+      '@zag-js/tooltip': 0.19.1
+      '@zag-js/types': 0.19.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - '@internationalized/date'
     dev: false
@@ -179,6 +304,32 @@ packages:
       - '@internationalized/date'
     dev: false
 
+  /@babel/helper-string-parser@7.23.4:
+    resolution: {integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/helper-validator-identifier@7.22.20:
+    resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
+  /@babel/parser@7.23.9:
+    resolution: {integrity: sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.23.9
+    dev: false
+
+  /@babel/runtime-corejs3@7.23.9:
+    resolution: {integrity: sha512-oeOFTrYWdWXCvXGB5orvMTJ6gCZ9I6FBjR+M38iKNXCsPxr4xT0RTdg5uz1H7QP8pp74IzPtwritEr+JscqHXQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      core-js-pure: 3.35.1
+      regenerator-runtime: 0.14.0
+    dev: false
+
   /@babel/runtime@7.23.2:
     resolution: {integrity: sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==}
     engines: {node: '>=6.9.0'}
@@ -186,15 +337,55 @@ packages:
       regenerator-runtime: 0.14.0
     dev: false
 
+  /@babel/types@7.23.9:
+    resolution: {integrity: sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.23.4
+      '@babel/helper-validator-identifier': 7.22.20
+      to-fast-properties: 2.0.0
+    dev: false
+
   /@braintree/sanitize-url@6.0.4:
     resolution: {integrity: sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==}
     dev: false
+
+  /@clack/core@0.3.3:
+    resolution: {integrity: sha512-5ZGyb75BUBjlll6eOa1m/IZBxwk91dooBWhPSL67sWcLS0zt9SnswRL0l26TVdBhb0wnWORRxUn//uH6n4z7+A==}
+    dependencies:
+      picocolors: 1.0.0
+      sisteransi: 1.0.5
+    dev: false
+
+  /@clack/prompts@0.6.3:
+    resolution: {integrity: sha512-AM+kFmAHawpUQv2q9+mcB6jLKxXGjgu/r2EQjEwujgpCdzrST6BJqYw00GRn56/L/Izw5U7ImoLmy00X/r80Pw==}
+    dependencies:
+      '@clack/core': 0.3.3
+      picocolors: 1.0.0
+      sisteransi: 1.0.5
+    dev: false
+    bundledDependencies:
+      - is-unicode-supported
+
+  /@emotion/is-prop-valid@0.8.8:
+    resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
+    requiresBuild: true
+    dependencies:
+      '@emotion/memoize': 0.7.4
+    dev: false
+    optional: true
 
   /@emotion/is-prop-valid@1.2.1:
     resolution: {integrity: sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==}
     dependencies:
       '@emotion/memoize': 0.8.1
     dev: false
+
+  /@emotion/memoize@0.7.4:
+    resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@emotion/memoize@0.8.1:
     resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
@@ -203,6 +394,204 @@ packages:
   /@emotion/unitless@0.8.0:
     resolution: {integrity: sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==}
     dev: false
+
+  /@esbuild/android-arm64@0.17.19:
+    resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/android-arm@0.17.19:
+    resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/android-x64@0.17.19:
+    resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/darwin-arm64@0.17.19:
+    resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/darwin-x64@0.17.19:
+    resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.17.19:
+    resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/freebsd-x64@0.17.19:
+    resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-arm64@0.17.19:
+    resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-arm@0.17.19:
+    resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-ia32@0.17.19:
+    resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-loong64@0.17.19:
+    resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-mips64el@0.17.19:
+    resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-ppc64@0.17.19:
+    resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-riscv64@0.17.19:
+    resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-s390x@0.17.19:
+    resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-x64@0.17.19:
+    resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/netbsd-x64@0.17.19:
+    resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/openbsd-x64@0.17.19:
+    resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/sunos-x64@0.17.19:
+    resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/win32-arm64@0.17.19:
+    resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/win32-ia32@0.17.19:
+    resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/win32-x64@0.17.19:
+    resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.56.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
@@ -247,6 +636,20 @@ packages:
       '@floating-ui/utils': 0.1.6
     dev: false
 
+  /@floating-ui/dom@1.5.1:
+    resolution: {integrity: sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==}
+    dependencies:
+      '@floating-ui/core': 1.5.2
+      '@floating-ui/utils': 0.1.6
+    dev: false
+
+  /@floating-ui/dom@1.5.2:
+    resolution: {integrity: sha512-6ArmenS6qJEWmwzczWyhvrXRdI/rI78poBcW0h/456+onlabit+2G+QxHx5xTOX60NBJQXjsCLFbW2CmsXpUog==}
+    dependencies:
+      '@floating-ui/core': 1.5.2
+      '@floating-ui/utils': 0.1.6
+    dev: false
+
   /@floating-ui/dom@1.5.3:
     resolution: {integrity: sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==}
     dependencies:
@@ -256,6 +659,14 @@ packages:
 
   /@floating-ui/utils@0.1.6:
     resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
+    dev: false
+
+  /@graphql-typed-document-node/core@3.2.0(graphql@16.8.1):
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 16.8.1
     dev: false
 
   /@headlessui/react@1.7.17(react-dom@18.2.0)(react@18.2.0):
@@ -290,6 +701,117 @@ packages:
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
     dev: true
 
+  /@inkeep/color-mode@0.0.21(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-ktTceeHaJEaxDkCM5SM/duk0DrevDN/RFKVuijlUW0bItMvWK7R8NItjdC+a61C6WOXp9W71hV6OZmnxix2f7w==}
+    peerDependencies:
+      react: ^18.2.0
+      react-dom: ^18.2.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@inkeep/components@0.0.21(@ark-ui/react@0.15.0)(@internationalized/date@3.5.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-kDCvXg3Hi3/eCPLJRu9UlZ3V2aSMxj0x9RXhR0WLPn31YG5+MWoPxy/3ESXibx0xDP7dgg4EoanneQGQCKyVKA==}
+    peerDependencies:
+      '@ark-ui/react': '>=0.15.0'
+      react: ^18.2.0
+      react-dom: ^18.2.0
+    dependencies:
+      '@ark-ui/react': 0.15.0(@internationalized/date@3.5.0)(react-dom@18.2.0)(react@18.2.0)
+      '@inkeep/preset': 0.0.21(@internationalized/date@3.5.0)(typescript@5.2.2)
+      '@inkeep/preset-chakra': 0.0.21(@internationalized/date@3.5.0)(typescript@5.2.2)
+      '@inkeep/shared': 0.0.22
+      '@inkeep/styled-system': 0.0.31
+      '@pandacss/dev': 0.22.1(typescript@5.2.2)
+      framer-motion: 10.18.0(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@internationalized/date'
+      - jsdom
+      - typescript
+    dev: false
+
+  /@inkeep/preset-chakra@0.0.21(@internationalized/date@3.5.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-FdgnJTz/h4/KefS+SQYhCQlqzLzaVU7/D/x9kr7Yr90xOSO3KauRXkBl2E9/cZgmqB1qgYXP48Y31P2RSlzljg==}
+    dependencies:
+      '@ark-ui/anatomy': 0.1.0(@internationalized/date@3.5.0)
+      '@inkeep/shared': 0.0.22
+      '@pandacss/dev': 0.22.1(typescript@5.2.2)
+    transitivePeerDependencies:
+      - '@internationalized/date'
+      - jsdom
+      - typescript
+    dev: false
+
+  /@inkeep/preset@0.0.21(@internationalized/date@3.5.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-g+JW6xriSaF/kfAK5dE0pLb2E1b6/GzKO6e51yDDLlN6jFlo17VCtWu5JDuwOAD3CA+K/O1PRbQdOy9zUtL7iQ==}
+    dependencies:
+      '@ark-ui/anatomy': 0.1.0(@internationalized/date@3.5.0)
+      '@inkeep/preset-chakra': 0.0.21(@internationalized/date@3.5.0)(typescript@5.2.2)
+      '@inkeep/shared': 0.0.22
+      '@pandacss/dev': 0.22.1(typescript@5.2.2)
+      colorjs.io: 0.4.5
+    transitivePeerDependencies:
+      - '@internationalized/date'
+      - jsdom
+      - typescript
+    dev: false
+
+  /@inkeep/shared@0.0.22:
+    resolution: {integrity: sha512-19eZbPpsHSJFdcAgNLQelX/czqqXXB0JDMfPg5dJiGU7GNHL5wYAJfxbYk1WmbqyKYrCiG/A0fNV9SGAPGt0Lw==}
+    dev: false
+
+  /@inkeep/styled-system@0.0.31:
+    resolution: {integrity: sha512-egmQwzn0SiXSSCZNItyxkbF4tcMXqyt6FJjOmGPbb9Lznk7yaTdmEarp+Q9Xxao7/VPRYAaXP6bBaouV/8Hdzw==}
+    dev: false
+
+  /@inkeep/styled-system@0.0.32:
+    resolution: {integrity: sha512-UcT2Q1e4kb1hSlGcY9tz/V2QzazQcLjXtcfloFwmkVKk4kLy2JtQS/Kf4P81ihuBsHhfOtXePUxuj5SS5nxstA==}
+    dev: false
+
+  /@inkeep/widgets@0.2.258(@internationalized/date@3.5.0)(@types/react@18.2.46)(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-9+Isvs9b1NRwg9kZmU7TZVTkMQfu/ZdvhmxMIehW4272vDpVtGfkACVon07zaTM2qNHFGGgsNp3NOOTxV7c0sg==}
+    peerDependencies:
+      react: ^18.2.0
+      react-dom: ^18.2.0
+    dependencies:
+      '@apollo/client': 3.8.10(graphql-ws@5.14.3)(graphql@16.8.1)(react-dom@18.2.0)(react@18.2.0)
+      '@ark-ui/react': 0.15.0(@internationalized/date@3.5.0)(react-dom@18.2.0)(react@18.2.0)
+      '@inkeep/color-mode': 0.0.21(react-dom@18.2.0)(react@18.2.0)
+      '@inkeep/components': 0.0.21(@ark-ui/react@0.15.0)(@internationalized/date@3.5.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+      '@inkeep/preset': 0.0.21(@internationalized/date@3.5.0)(typescript@5.2.2)
+      '@inkeep/preset-chakra': 0.0.21(@internationalized/date@3.5.0)(typescript@5.2.2)
+      '@inkeep/shared': 0.0.22
+      '@inkeep/styled-system': 0.0.32
+      '@types/lodash.isequal': 4.5.8
+      graphql: 16.8.1
+      graphql-ws: 5.14.3(graphql@16.8.1)
+      html-react-parser: 3.0.16(react@18.2.0)
+      lodash.isequal: 4.5.0
+      prism-react-renderer: 2.3.1(react@18.2.0)
+      prismjs: 1.29.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-error-boundary: 4.0.12(react@18.2.0)
+      react-hotkeys-hook: 4.4.4(react-dom@18.2.0)(react@18.2.0)
+      react-icons: 4.12.0(react@18.2.0)
+      react-markdown: 8.0.7(@types/react@18.2.46)(react@18.2.0)
+      react-shadow: 20.4.0(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
+      react-textarea-autosize: 8.5.3(@types/react@18.2.46)(react@18.2.0)
+      rehype-raw: 6.1.1
+      xregexp: 5.1.1
+    transitivePeerDependencies:
+      - '@internationalized/date'
+      - '@types/react'
+      - jsdom
+      - prop-types
+      - subscriptions-transport-ws
+      - supports-color
+      - typescript
+    dev: false
+
   /@internationalized/date@3.5.0:
     resolution: {integrity: sha512-nw0Q+oRkizBWMioseI8+2TeUPEyopJVz5YxoYVzR0W1v+2YytiYah7s/ot35F149q/xAg4F1gT/6eTd+tsUpFQ==}
     dependencies:
@@ -323,7 +845,6 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.20:
     resolution: {integrity: sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==}
@@ -591,12 +1112,10 @@ packages:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
-    dev: true
 
   /@nodelib/fs.stat@2.0.5:
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
-    dev: true
 
   /@nodelib/fs.walk@1.2.8:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
@@ -604,7 +1123,206 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
-    dev: true
+
+  /@pandacss/config@0.22.1:
+    resolution: {integrity: sha512-odnBV0U7ZiehR8O4hA+XbqWuBxhEl//XVtiyfr2KIRy53oFuNudOFFwGDQPcowcVCVl+lzclsjByr9UT+tdT6Q==}
+    dependencies:
+      '@pandacss/error': 0.22.1
+      '@pandacss/logger': 0.22.1
+      '@pandacss/preset-base': 0.22.1
+      '@pandacss/preset-panda': 0.22.1
+      '@pandacss/shared': 0.22.1
+      '@pandacss/types': 0.22.1
+      bundle-n-require: 1.0.1
+      escalade: 3.1.1
+      jiti: 1.21.0
+      merge-anything: 5.1.7
+      typescript: 5.3.3
+    dev: false
+
+  /@pandacss/core@0.22.1:
+    resolution: {integrity: sha512-fjtpxHuE5R3F8qQmz3U5jK3/N+D1ewr9VqP/fbPMugH05x+UrT/y+eVZWzZK/N3MCqNjKKjI2j7cvEuTcvYppw==}
+    dependencies:
+      '@pandacss/error': 0.22.1
+      '@pandacss/logger': 0.22.1
+      '@pandacss/shared': 0.22.1
+      '@pandacss/token-dictionary': 0.22.1
+      '@pandacss/types': 0.22.1
+      autoprefixer: 10.4.15(postcss@8.4.31)
+      hookable: 5.5.3
+      lodash.merge: 4.6.2
+      postcss: 8.4.31
+      postcss-discard-duplicates: 6.0.1(postcss@8.4.31)
+      postcss-discard-empty: 6.0.1(postcss@8.4.31)
+      postcss-merge-rules: 6.0.3(postcss@8.4.31)
+      postcss-minify-selectors: 6.0.2(postcss@8.4.31)
+      postcss-nested: 6.0.1(postcss@8.4.31)
+      postcss-normalize-whitespace: 6.0.1(postcss@8.4.31)
+      postcss-selector-parser: 6.0.13
+      ts-pattern: 5.0.5
+    dev: false
+
+  /@pandacss/dev@0.22.1(typescript@5.2.2):
+    resolution: {integrity: sha512-/w6OUwDeL4lM2mVYGBcX/sBcGYaPNLoakTRbLBjo/V/Kc/tTpycuGpag9wHG/ZD58upe6dl4biJ33oFW3B7X4A==}
+    hasBin: true
+    dependencies:
+      '@clack/prompts': 0.6.3
+      '@pandacss/config': 0.22.1
+      '@pandacss/error': 0.22.1
+      '@pandacss/logger': 0.22.1
+      '@pandacss/node': 0.22.1(typescript@5.2.2)
+      '@pandacss/postcss': 0.22.1(typescript@5.2.2)
+      '@pandacss/preset-panda': 0.22.1
+      '@pandacss/shared': 0.22.1
+      '@pandacss/token-dictionary': 0.22.1
+      '@pandacss/types': 0.22.1
+      cac: 6.7.14
+      pathe: 1.1.1
+      perfect-debounce: 1.0.0
+    transitivePeerDependencies:
+      - jsdom
+      - typescript
+    dev: false
+
+  /@pandacss/error@0.22.1:
+    resolution: {integrity: sha512-o9vlQBvkaM+4wHhnC8qDBk0GxrCj8KIipheU8BDwLke3ZBq4neL5IMSXB+Vpl/7GFCJFZ/C7TThA1nrAmTa9hg==}
+    dev: false
+
+  /@pandacss/extractor@0.22.1(typescript@5.2.2):
+    resolution: {integrity: sha512-OgPJ0gtGRFExsQQWjIWpsMfMM2XzfafkYh3Q86fR0ap+M4XXcsd3pR9fuoCquZeYnCSe4vpot4TLVwqvB3Ft2Q==}
+    dependencies:
+      ts-evaluator: 1.2.0(typescript@5.2.2)
+      ts-morph: 19.0.0
+    transitivePeerDependencies:
+      - jsdom
+      - typescript
+    dev: false
+
+  /@pandacss/generator@0.22.1:
+    resolution: {integrity: sha512-rufPl/szF5zoxx35n3qCIy27QoAN5KnA04zQQUNLOFj/c9UVdTLNMOxr8qAMyg4Fq7Seb8utSLxyiW1O07ae9Q==}
+    dependencies:
+      '@pandacss/core': 0.22.1
+      '@pandacss/is-valid-prop': 0.22.1
+      '@pandacss/logger': 0.22.1
+      '@pandacss/shared': 0.22.1
+      '@pandacss/token-dictionary': 0.22.1
+      '@pandacss/types': 0.22.1
+      javascript-stringify: 2.1.0
+      lil-fp: 1.4.5
+      outdent: 0.8.0
+      pluralize: 8.0.0
+      postcss: 8.4.31
+      ts-pattern: 5.0.5
+    dev: false
+
+  /@pandacss/is-valid-prop@0.22.1:
+    resolution: {integrity: sha512-V+BbtP3EfubDleauz604kry6moqLAfP+Mx5S6CMR3yAnLTZ/yhDYOphMdnG8+30KKyNrAwtXQ0XJtAFw2E9Kug==}
+    dev: false
+
+  /@pandacss/logger@0.22.1:
+    resolution: {integrity: sha512-Li/89stP87TedBVFKZ0jh2gPLVKynKkEbbmiizsPC9GebsL6kUHRHVdAoorkcgIA21L5X9Gt58UKT8l2Wi2M3A==}
+    dependencies:
+      kleur: 4.1.5
+      lil-fp: 1.4.5
+    dev: false
+
+  /@pandacss/node@0.22.1(typescript@5.2.2):
+    resolution: {integrity: sha512-a+Lq6SXP4BLPFtE2mq8TrEA4knaPltFccs/F9oyoEBOpgLwJstKj/lqf/Q1iXVdMAAVkPGNtjfdox5kxoGGzrw==}
+    dependencies:
+      '@pandacss/config': 0.22.1
+      '@pandacss/core': 0.22.1
+      '@pandacss/error': 0.22.1
+      '@pandacss/extractor': 0.22.1(typescript@5.2.2)
+      '@pandacss/generator': 0.22.1
+      '@pandacss/is-valid-prop': 0.22.1
+      '@pandacss/logger': 0.22.1
+      '@pandacss/parser': 0.22.1(typescript@5.2.2)
+      '@pandacss/shared': 0.22.1
+      '@pandacss/token-dictionary': 0.22.1
+      '@pandacss/types': 0.22.1
+      chokidar: 3.5.3
+      fast-glob: 3.3.2
+      file-size: 1.0.0
+      filesize: 10.1.0
+      fs-extra: 11.1.1
+      glob-parent: 6.0.2
+      hookable: 5.5.3
+      is-glob: 4.0.3
+      lil-fp: 1.4.5
+      lodash.merge: 4.6.2
+      look-it-up: 2.1.0
+      microdiff: 1.3.2
+      outdent: 0.8.0
+      pathe: 1.1.1
+      pkg-types: 1.0.3
+      pluralize: 8.0.0
+      postcss: 8.4.31
+      preferred-pm: 3.1.2
+      prettier: 2.8.8
+      ts-morph: 19.0.0
+      ts-pattern: 5.0.5
+      tsconfck: 2.1.2(typescript@5.2.2)
+    transitivePeerDependencies:
+      - jsdom
+      - typescript
+    dev: false
+
+  /@pandacss/parser@0.22.1(typescript@5.2.2):
+    resolution: {integrity: sha512-uKSpQeVDtG5uF4M1It/SOBjFmyKnDbFaJINVa/wFy5kgETn63jalOaenFTi0YEEzeaIIrElb1mIW6AlqhgYEKw==}
+    dependencies:
+      '@pandacss/config': 0.22.1
+      '@pandacss/extractor': 0.22.1(typescript@5.2.2)
+      '@pandacss/is-valid-prop': 0.22.1
+      '@pandacss/logger': 0.22.1
+      '@pandacss/shared': 0.22.1
+      '@pandacss/types': 0.22.1
+      '@vue/compiler-sfc': 3.4.15
+      lil-fp: 1.4.5
+      magic-string: 0.30.5
+      ts-morph: 19.0.0
+      ts-pattern: 5.0.5
+    transitivePeerDependencies:
+      - jsdom
+      - typescript
+    dev: false
+
+  /@pandacss/postcss@0.22.1(typescript@5.2.2):
+    resolution: {integrity: sha512-DzPT8zwsRrPtfzoVXkt2x576veN7bzyF3wERPIOYUtbEkd8uUCunqLoazcMyuUfOaUv9X5pqQkPqsH1glSJ6Dg==}
+    dependencies:
+      '@pandacss/node': 0.22.1(typescript@5.2.2)
+      postcss: 8.4.31
+    transitivePeerDependencies:
+      - jsdom
+      - typescript
+    dev: false
+
+  /@pandacss/preset-base@0.22.1:
+    resolution: {integrity: sha512-oqYxrrkafBCzBHBaBKA9/7ELq6+j5rkJ4qK0wkePGHxvV1pIN6pG7mSNCGsCpwNZ84ELk9lwzbOFCGEb3hxisQ==}
+    dependencies:
+      '@pandacss/types': 0.22.1
+    dev: false
+
+  /@pandacss/preset-panda@0.22.1:
+    resolution: {integrity: sha512-9wou8j500OGa4b54YBV2x+0CMO6J1lG+cmHvht2yJ8Yr3xQXe34qIdeUvoAeG4harOdrdEz2x1AbteYK18RrJw==}
+    dependencies:
+      '@pandacss/types': 0.22.1
+    dev: false
+
+  /@pandacss/shared@0.22.1:
+    resolution: {integrity: sha512-DhuwZ37vyoHHwD5XmiyErhmXmor+2dhfirwz+LnXTVV6LkYr3QdIBpd4cABx9xQTltVhwm13BfEf45DezsFdtQ==}
+    dev: false
+
+  /@pandacss/token-dictionary@0.22.1:
+    resolution: {integrity: sha512-GKMNo+lrfnZ/NecKeiRBXTSlpVT0cpBPZzN537ZuW7pM5PNhAD8EJDd1F+SkMb+ydfeff1VC66JYjL2c/ZCxjA==}
+    dependencies:
+      '@pandacss/shared': 0.22.1
+      '@pandacss/types': 0.22.1
+      ts-pattern: 5.0.5
+    dev: false
+
+  /@pandacss/types@0.22.1:
+    resolution: {integrity: sha512-WZCQrTa5wlenBStlu0gntKGi4dWA96LCft1oEqdh2u6VPK0sEfqk0wjyJGps/YN3pNjNKiQW3b4p1Wx+RshlYA==}
+    dev: false
 
   /@phosphor-icons/react@2.0.15(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-PQKNcRrfERlC8gJGNz0su0i9xVmeubXSNxucPcbCLDd9u0cwJVTEyYK87muul/svf0UXFdL2Vl6bbeOhT1Mwow==}
@@ -886,6 +1604,15 @@ packages:
       unist-util-visit: 5.0.0
     dev: false
 
+  /@ts-morph/common@0.20.0:
+    resolution: {integrity: sha512-7uKjByfbPpwuzkstL3L5MQyuXPSKdoNG93Fmi2JoDcTf3pEP731JdRFAduRVkOs8oqxPsXKA+ScrWkdQ8t/I+Q==}
+    dependencies:
+      fast-glob: 3.3.2
+      minimatch: 7.4.6
+      mkdirp: 2.1.6
+      path-browserify: 1.0.1
+    dev: false
+
   /@types/acorn@4.0.6:
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
     dependencies:
@@ -942,6 +1669,16 @@ packages:
     resolution: {integrity: sha512-rZYO1HInM99rAFYNwGqbYPxHZHxu2IwZYKj4bJ4oh6edVrm1UId8mmbHIZLBtG253qU6y3piag0XYe/joNnwzQ==}
     dev: false
 
+  /@types/lodash.isequal@4.5.8:
+    resolution: {integrity: sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==}
+    dependencies:
+      '@types/lodash': 4.14.202
+    dev: false
+
+  /@types/lodash@4.14.202:
+    resolution: {integrity: sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==}
+    dev: false
+
   /@types/mdast@3.0.15:
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
     dependencies:
@@ -968,11 +1705,23 @@ packages:
       '@types/unist': 2.0.10
     dev: false
 
+  /@types/node@17.0.45:
+    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+    dev: false
+
   /@types/node@20.9.0:
     resolution: {integrity: sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==}
     dependencies:
       undici-types: 5.26.5
     dev: true
+
+  /@types/parse5@6.0.3:
+    resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}
+    dev: false
+
+  /@types/prismjs@1.26.3:
+    resolution: {integrity: sha512-A0D0aTXvjlqJ5ZILMz3rNfDBOx9hHxLZYv2by47Sm/pqW35zzjusrZTryatjN/Rf8Us2gZrJD+KeHbUSTux1Cw==}
+    dev: false
 
   /@types/prop-types@15.7.10:
     resolution: {integrity: sha512-mxSnDQxPqsZxmeShFH+uwQ4kO4gcJcGahjjMFeLbKE95IAZiiZyiEepGZjtXJ7hN/yfu0bu9xN2ajcU0JcxX6A==}
@@ -1138,6 +1887,105 @@ packages:
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
+  /@vue/compiler-core@3.4.15:
+    resolution: {integrity: sha512-XcJQVOaxTKCnth1vCxEChteGuwG6wqnUHxAm1DO3gCz0+uXKaJNx8/digSz4dLALCy8n2lKq24jSUs8segoqIw==}
+    dependencies:
+      '@babel/parser': 7.23.9
+      '@vue/shared': 3.4.15
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.0.2
+    dev: false
+
+  /@vue/compiler-dom@3.4.15:
+    resolution: {integrity: sha512-wox0aasVV74zoXyblarOM3AZQz/Z+OunYcIHe1OsGclCHt8RsRm04DObjefaI82u6XDzv+qGWZ24tIsRAIi5MQ==}
+    dependencies:
+      '@vue/compiler-core': 3.4.15
+      '@vue/shared': 3.4.15
+    dev: false
+
+  /@vue/compiler-sfc@3.4.15:
+    resolution: {integrity: sha512-LCn5M6QpkpFsh3GQvs2mJUOAlBQcCco8D60Bcqmf3O3w5a+KWS5GvYbrrJBkgvL1BDnTp+e8q0lXCLgHhKguBA==}
+    dependencies:
+      '@babel/parser': 7.23.9
+      '@vue/compiler-core': 3.4.15
+      '@vue/compiler-dom': 3.4.15
+      '@vue/compiler-ssr': 3.4.15
+      '@vue/shared': 3.4.15
+      estree-walker: 2.0.2
+      magic-string: 0.30.5
+      postcss: 8.4.33
+      source-map-js: 1.0.2
+    dev: false
+
+  /@vue/compiler-ssr@3.4.15:
+    resolution: {integrity: sha512-1jdeQyiGznr8gjFDadVmOJqZiLNSsMa5ZgqavkPZ8O2wjHv0tVuAEsw5hTdUoUW4232vpBbL/wJhzVW/JwY1Uw==}
+    dependencies:
+      '@vue/compiler-dom': 3.4.15
+      '@vue/shared': 3.4.15
+    dev: false
+
+  /@vue/shared@3.4.15:
+    resolution: {integrity: sha512-KzfPTxVaWfB+eGcGdbSf4CWdaXcGDqckoeXUh7SB3fZdEtzPCK2Vq9B/lRRL3yutax/LWITz+SwvgyOxz5V75g==}
+    dev: false
+
+  /@wry/caches@1.0.1:
+    resolution: {integrity: sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@wry/context@0.7.4:
+    resolution: {integrity: sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@wry/equality@0.5.7:
+    resolution: {integrity: sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@wry/trie@0.4.3:
+    resolution: {integrity: sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@wry/trie@0.5.0:
+    resolution: {integrity: sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@zag-js/accordion@0.19.1:
+    resolution: {integrity: sha512-AiJUEQq/GzUuZnwdP3LeOa+0nw0JQt7HY5Xmj7lXicniLKXcRe0ixm8GqqerAWWfWXRd4G0vjuyxx2U4khKOzQ==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/accordion@0.20.0:
+    resolution: {integrity: sha512-oc5PN2ZZHgne9EzXgHYFFJ2D1hHciOHjkgNRUXCNa3fXKaV3em03Y2fo3b1oB78jySH86BgXFrWXE/dAnCsStQ==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+    dev: false
+
   /@zag-js/accordion@0.30.0:
     resolution: {integrity: sha512-Wvk/czB9NYeAy0KOo6q45NiQ3d3URTxWlntrknP3pq1sw4HCdraqpl8jv9f3eg+gnTAeZWYwBr/jlWvfs67KMQ==}
     dependencies:
@@ -1149,8 +1997,28 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/anatomy@0.19.1:
+    resolution: {integrity: sha512-OAS1ySa2+j7bCmn8lIhJo8fWs6qSEAxm2tAb4CHesOZf+Uv/pbpGCXSS37PCrp+NyjRG+8qStSJqjuvMNacAKg==}
+    dev: false
+
+  /@zag-js/anatomy@0.20.0:
+    resolution: {integrity: sha512-xemaUuEd5cVEwCjCR/N/Gx1iga6bGDMBfEayZKbUIQ2pn+st6f0u7LM2He2nELYa19hxCJSSMxvLZPw2PhpPbA==}
+    dev: false
+
   /@zag-js/anatomy@0.30.0:
     resolution: {integrity: sha512-tPtFGw2PO+dUtMXl/5C1wMfWsh6V7lRygENvro58nP02/T6EnMyqH6D1tz6bPGC0RZc0BpXt2/+cMeq9hs4kxQ==}
+    dev: false
+
+  /@zag-js/aria-hidden@0.19.1:
+    resolution: {integrity: sha512-7Ev/HX7CmOpDhOn49JoputgqbJKmgiK5qAqEnKaIFgELvDySVZ2IoUOT6Yd5gU6MDDqWDVNE83auu15nmH5/6A==}
+    dependencies:
+      '@zag-js/dom-query': 0.19.1
+    dev: false
+
+  /@zag-js/aria-hidden@0.20.0:
+    resolution: {integrity: sha512-wvmrbT5BVAhVihlu0iA5L3zpoVb/O9Y+OUxMkLEBXKRke2FWJM7uR2BSxnSniB1aDf6l12Ca95sUrfsNBGUnvw==}
+    dependencies:
+      '@zag-js/dom-query': 0.20.0
     dev: false
 
   /@zag-js/aria-hidden@0.30.0:
@@ -1159,10 +2027,44 @@ packages:
       '@zag-js/dom-query': 0.30.0
     dev: false
 
+  /@zag-js/auto-resize@0.19.1:
+    resolution: {integrity: sha512-KJ1u0Tm0fkp/FD4k+R4+VNt7mFOEeAsdoCCr18Ohwhkdui3dFHHq8H6JFHEGkWa69vo083dEyiQzKWxYKUdwtg==}
+    dependencies:
+      '@zag-js/dom-query': 0.19.1
+    dev: false
+
+  /@zag-js/auto-resize@0.20.0:
+    resolution: {integrity: sha512-LGiMQqmE1YK/Ptd8xU6jRvq8m9DS/Z9WYL+izq0QQhXth/R2vgQDzU6DDbYDpSbE0f7f2k3if1yc3WAd4gh4IA==}
+    dependencies:
+      '@zag-js/dom-query': 0.20.0
+    dev: false
+
   /@zag-js/auto-resize@0.30.0:
     resolution: {integrity: sha512-khlb77zoSp+M7hvWiJapQDFpyFABS/RckrTXwlbAFbDaAgeGWYBajYS4vsKF+gbjT9EJpNsocjAr/myJS2WjQg==}
     dependencies:
       '@zag-js/dom-query': 0.30.0
+    dev: false
+
+  /@zag-js/avatar@0.19.1:
+    resolution: {integrity: sha512-XPbpAzXfWkRmBb7Als5KgJTMNgJUwu+B0R/412OARdAglk/g4aB62gu5xS06GxRJ43RLzcXNSmUMePrvYsNrcw==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/mutation-observer': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/avatar@0.20.0:
+    resolution: {integrity: sha512-nvmeEgYXVvtZVT9jStR18TdzPoiUz5ylOCQ+wAsOaTARVSg/c0MMyINj7GIrTUF+E0zUDcbK7G8ndI+LjpDnog==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/mutation-observer': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
     dev: false
 
   /@zag-js/avatar@0.30.0:
@@ -1176,6 +2078,26 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/carousel@0.19.1:
+    resolution: {integrity: sha512-aWmKZVWZf0CdNbrKvuhRwZBMnh/hE0ckleQZ7048NGXbYNUDMq+7Ni/9Xu9IgFbZ6oRvE35rkXvFuXKD5cCUWA==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/carousel@0.20.0:
+    resolution: {integrity: sha512-0vDFI8i5VPExjRbcPmfo9UhYttgLxuINkABw/FlMK4iDhmk8xifUn59555ZWBcs3ZPAAXEzwXOolPn8TjsBfnw==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+    dev: false
+
   /@zag-js/carousel@0.30.0:
     resolution: {integrity: sha512-ozek4hH/hanGtcfKiZx0u+cmptuWm1lC5N13yh8jL9Xx0veeWDA9Atkqo3fZlWrkQz01sI8gYs/QGa1gHMRauQ==}
     dependencies:
@@ -1184,6 +2106,30 @@ packages:
       '@zag-js/dom-query': 0.30.0
       '@zag-js/types': 0.30.0
       '@zag-js/utils': 0.30.0
+    dev: false
+
+  /@zag-js/checkbox@0.19.1:
+    resolution: {integrity: sha512-NU1Hm0PwLmsXpDM8uPbd1FwQ0+1PaCYxZr3bUsH90Rw9buMs5ImCCDP9MCb3wOxZaCCPlC+14/U/cU3cjfe+VA==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/form-utils': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+      '@zag-js/visually-hidden': 0.19.1
+    dev: false
+
+  /@zag-js/checkbox@0.20.0:
+    resolution: {integrity: sha512-DGFnACSOCzgFlltnTgbZ69PwgWTMZSS5Jz+0uOXGlFQYGNbnM4YwcWbklQWfbyq+YuBW3Gj5h+eDflngeQhQog==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/form-utils': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+      '@zag-js/visually-hidden': 0.20.0
     dev: false
 
   /@zag-js/checkbox@0.30.0:
@@ -1198,8 +2144,48 @@ packages:
       '@zag-js/visually-hidden': 0.30.0
     dev: false
 
+  /@zag-js/collection@0.19.1:
+    resolution: {integrity: sha512-cuLKbcfMHxyVldk5/vVHk61fjkmvNugGbPi+PUHpejMFqCyBElfoVcMnb9I5RBabWNlSM66UpThLypv5USEtbw==}
+    dev: false
+
+  /@zag-js/collection@0.20.0:
+    resolution: {integrity: sha512-C+g6bJkgz84akSqkJF+9d3XagJISe1zQvnwNdqQwCIJc4ccF3t2V6fIb0i28NX+Cm+wLQiOfPwdboWnv4KK7nw==}
+    dev: false
+
   /@zag-js/collection@0.30.0:
     resolution: {integrity: sha512-pynST1n0HEF38/rjqdVck7rTd2x2eHkT4TXe1oundzCpsaR+hIbneWp0NVlEbusI44PdR5kMPYFn032oD4L1Pw==}
+    dev: false
+
+  /@zag-js/color-picker@0.19.1:
+    resolution: {integrity: sha512-fT97H84fZgQyUdHFwlifieMQQte6Tu7P7G5A59uTKQJqZJdfuaX3liu8nJskADcC5/IvhYJ8ExQnIcgCmw6ESA==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/color-utils': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/form-utils': 0.19.1
+      '@zag-js/numeric-range': 0.19.1
+      '@zag-js/text-selection': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+      '@zag-js/visually-hidden': 0.19.1
+    dev: false
+
+  /@zag-js/color-picker@0.20.0:
+    resolution: {integrity: sha512-VUripimINXmOmugAp1SiJj2Hqx8n8BN5E75Gek4A7ZXzualI+aG61yGgEIzF+VzPJmzKmQGJ9CDslXCljZNiig==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/color-utils': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/form-utils': 0.20.0
+      '@zag-js/numeric-range': 0.20.0
+      '@zag-js/text-selection': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+      '@zag-js/visually-hidden': 0.20.0
     dev: false
 
   /@zag-js/color-picker@0.30.0:
@@ -1220,10 +2206,50 @@ packages:
       '@zag-js/visually-hidden': 0.30.0
     dev: false
 
+  /@zag-js/color-utils@0.19.1:
+    resolution: {integrity: sha512-ZeN6IcW7pYl0Ib5nDwB0Q4KlqCxCi9SVOiQFLeMvvC+/v0wme+z6yPmWybeD6nl9vySLC7xrLrxeaSy/fRee1A==}
+    dev: false
+
+  /@zag-js/color-utils@0.20.0:
+    resolution: {integrity: sha512-7aLOKVhoUfhclspjHywZbyKzsMZpMzmESQInD+Uw3/WUj/HQdi+BKFCGI+kONoE7Usuf27N7r4eebdxMEcnlOg==}
+    dev: false
+
   /@zag-js/color-utils@0.30.0:
     resolution: {integrity: sha512-OsCGhm0+28xMvfF1EfXqtblG7xFCwt1FhrXxZnnXDJSjwxvB3pmwPAFCL6nauH39LG53+Qb3dgt768oGVVYk7A==}
     dependencies:
       '@zag-js/numeric-range': 0.30.0
+    dev: false
+
+  /@zag-js/combobox@0.19.1:
+    resolution: {integrity: sha512-5BHRuS7IiCQFgUbIKMEnjLQsJbc1v3ZPbqZXuPbR0mzIpHbnfxgcajLoDzL/UGf2o8a9eHRpz1OFt6iFh1u4hQ==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/aria-hidden': 0.19.1
+      '@zag-js/collection': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dismissable': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/mutation-observer': 0.19.1
+      '@zag-js/popper': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/combobox@0.20.0:
+    resolution: {integrity: sha512-r6aRlPMkfeVIpdD0kL7N39TWQi0hFFZmNH5grMno1APVl/yHNYEgQsa5y9qjnjaxbfuCJUBteb8n83gHf/HmJg==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/aria-hidden': 0.20.0
+      '@zag-js/collection': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dismissable': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/mutation-observer': 0.20.0
+      '@zag-js/popper': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
     dev: false
 
   /@zag-js/combobox@0.30.0:
@@ -1242,11 +2268,61 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/core@0.19.1:
+    resolution: {integrity: sha512-gsECy/F0EWqOxs2DUeDoNVgQn5xDDhQeN65iXRHYrtTeoox8Q99su1DPdTycvy2aF5+GGtC1zwlMMtZ6QimTFw==}
+    dependencies:
+      '@zag-js/store': 0.19.1
+      klona: 2.0.6
+    dev: false
+
+  /@zag-js/core@0.20.0:
+    resolution: {integrity: sha512-sTdn5row6sb+VyP7Dvwc79PiwVxw4P+/AW/6UaSVCevwH85MvhwQZVotaq13vfYMHeORwuDz9Q5ofN/6O+nJjw==}
+    dependencies:
+      '@zag-js/store': 0.20.0
+      klona: 2.0.6
+    dev: false
+
   /@zag-js/core@0.30.0:
     resolution: {integrity: sha512-z/VFXsRQGCrpHCxcxj8swKO5WHj0e8WGs+jLwU63oEfD8kYRwpem2AfbE9tqIJTlY/StCZFz1KM/rFN+wjEVYw==}
     dependencies:
       '@zag-js/store': 0.30.0
       klona: 2.0.6
+    dev: false
+
+  /@zag-js/date-picker@0.19.1:
+    resolution: {integrity: sha512-wANWb2DoN0K4GId7780/aXB8nFm3GAMca3tZv53yFi6xgmSQNMVORbA9ZeRdUbxVog2e8x2nbSVmR5vviAdtpw==}
+    dependencies:
+      '@internationalized/date': 3.5.0
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/date-utils': 0.19.1(@internationalized/date@3.5.0)
+      '@zag-js/dismissable': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/form-utils': 0.19.1
+      '@zag-js/live-region': 0.19.1
+      '@zag-js/popper': 0.19.1
+      '@zag-js/text-selection': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/date-picker@0.20.0:
+    resolution: {integrity: sha512-WoOVCcIjfwJ7GLgXssG+8CkG5nPMZWRZfqQHUaZxSdS7ppFRqCh84e442lpe9ahC1NGIwkdqrGSMbPs3BoKm4Q==}
+    dependencies:
+      '@internationalized/date': 3.5.0
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/date-utils': 0.20.0(@internationalized/date@3.5.0)
+      '@zag-js/dismissable': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/form-utils': 0.20.0
+      '@zag-js/live-region': 0.20.0
+      '@zag-js/popper': 0.20.0
+      '@zag-js/text-selection': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
     dev: false
 
   /@zag-js/date-picker@0.30.0:
@@ -1267,12 +2343,56 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/date-utils@0.19.1(@internationalized/date@3.5.0):
+    resolution: {integrity: sha512-oGwwnb8HuEsLjeh0baB8/t2YoL+qv3YRQNKfmxGIppYMY8heuYRr/PAOWkBbQIGOrd90y+cg1MeXeuwkWeAIDA==}
+    peerDependencies:
+      '@internationalized/date': '>=3.0.0'
+    dependencies:
+      '@internationalized/date': 3.5.0
+    dev: false
+
+  /@zag-js/date-utils@0.20.0(@internationalized/date@3.5.0):
+    resolution: {integrity: sha512-3HnqYJVZWFtrEeOI/1W0t2U3DIaNW/GpmA3VO3DD1iVt0TBOXDCfQAyOaHRujoB6ijB0yajT7pSUNoGtxepM9Q==}
+    peerDependencies:
+      '@internationalized/date': '>=3.0.0'
+    dependencies:
+      '@internationalized/date': 3.5.0
+    dev: false
+
   /@zag-js/date-utils@0.30.0(@internationalized/date@3.5.0):
     resolution: {integrity: sha512-oOyZnDSPeWo0c+gF1J1iwViAK9eLS/QNazOiQ56E3Rg95KzzzWStuXIn33zZSt2bYsLklxq20TlZIWIIfL5TlQ==}
     peerDependencies:
       '@internationalized/date': '>=3.0.0'
     dependencies:
       '@internationalized/date': 3.5.0
+    dev: false
+
+  /@zag-js/dialog@0.19.1:
+    resolution: {integrity: sha512-p3t60exZ2igWK+lQQ3DsPQEAb2AVgXgghb9t1R0uPxX5MET7d0lR+o9f9wuYC6jwY5ZDn1dkSguUwgX0UakaAA==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/aria-hidden': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dismissable': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/remove-scroll': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+      focus-trap: 7.5.2
+    dev: false
+
+  /@zag-js/dialog@0.20.0:
+    resolution: {integrity: sha512-PN9dHFCD2mFbVgTKxC3dyZbbxG5B4aHiAxKBG+eLFECkX/k98WQHSvTQ/RpKqGT0Izx6ioD1wu5BEdk7HtDdtQ==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/aria-hidden': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dismissable': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/remove-scroll': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+      focus-trap: 7.5.2
     dev: false
 
   /@zag-js/dialog@0.30.0:
@@ -1289,6 +2409,24 @@ packages:
       focus-trap: 7.5.4
     dev: false
 
+  /@zag-js/dismissable@0.19.1:
+    resolution: {integrity: sha512-58PHDosyp7xs2xUnipX+4DvMShoqjTtfK/AYkJn7l3OwmWBYw5emicmSpa+RTvk6POwZ2p71rMHg5cPvOVIy9Q==}
+    dependencies:
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/interact-outside': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/dismissable@0.20.0:
+    resolution: {integrity: sha512-E3qCELmtL541dSr6TPZ6w3FUeBHAJJAoD0ziGu6VdBdPOaivsEQcoxpQ2gWLkXcq4+G4GTY+O3uiz7FBwCMTag==}
+    dependencies:
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/interact-outside': 0.20.0
+      '@zag-js/utils': 0.20.0
+    dev: false
+
   /@zag-js/dismissable@0.30.0:
     resolution: {integrity: sha512-tgL5O+W6p8Jr8JPqPwDzEwIFfZ56GAH3Br7mT20WNL/9NI06+PFlo+VCmDN4NnBNlGMbZTY94raD5GaRU0GZ3Q==}
     dependencies:
@@ -1298,6 +2436,20 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/dom-event@0.19.1:
+    resolution: {integrity: sha512-XT2Qd3fCkHtyNgO8M0tZkrTj2GNBQz7L5mKEWK/aUIpmRb92k0UtlFZdIAX7lZL9ucw9n4cPhjbuOu8U7eylbw==}
+    dependencies:
+      '@zag-js/text-selection': 0.19.1
+      '@zag-js/types': 0.19.1
+    dev: false
+
+  /@zag-js/dom-event@0.20.0:
+    resolution: {integrity: sha512-LVQH+/PdzY6i8IyVefxKL3HPNm7xq/kwxaBJLxpm8wVnwA5qa0YvWIXMCx6mOnHAdNEbrjcZjk+5/73tQrer7A==}
+    dependencies:
+      '@zag-js/text-selection': 0.20.0
+      '@zag-js/types': 0.20.0
+    dev: false
+
   /@zag-js/dom-event@0.30.0:
     resolution: {integrity: sha512-nYtG30E+f7w5jxFE/qmjcC7d/z8lAzT6n897YwrB2ic17VXWqN6LE7NduYfB62n3BF5hTDeWGgZEfaP0JQtPzQ==}
     dependencies:
@@ -1305,8 +2457,42 @@ packages:
       '@zag-js/types': 0.30.0
     dev: false
 
+  /@zag-js/dom-query@0.19.1:
+    resolution: {integrity: sha512-X4DatqXZb5/rqmi3Y+AtBHkIRbdxNG9u207RRIBtcSO/XC2XC8x1DaQ5W/S746Dh4IUzTMyRvIu8e4wOZ2zdVg==}
+    dev: false
+
+  /@zag-js/dom-query@0.20.0:
+    resolution: {integrity: sha512-/jGdwjR42uDZlFEP3zu+mKtBGq2zaajfDqvI+dZmXU+EIVlNHfxyNwKIlMEXlvmZAOx7J+pJbCJkhBmedrcA/A==}
+    dev: false
+
   /@zag-js/dom-query@0.30.0:
     resolution: {integrity: sha512-cNIxL+ySzy8C13tEoDoo+B/j3rVFON3VCJXwieja1izcl+65yr88sJQmEGbOq/zuNTCWA9hijeimhv4c3zht9Q==}
+    dev: false
+
+  /@zag-js/editable@0.19.1:
+    resolution: {integrity: sha512-o8n+Bb8T7pVJyIKJAPu7I5iUAFl1iiLiyjRu6RDkvgGfRAe3WHj9vu2QkKbvUcpm2uuFVq68b2YUDfFkFjz0jQ==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/form-utils': 0.19.1
+      '@zag-js/interact-outside': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/editable@0.20.0:
+    resolution: {integrity: sha512-jdCc7R3StqVaSh1a5HeetRrDP+7kfUk+pxGXINiBG9FFMhCo5jZzIibeQ0rni1d2uEqS1rI0RQZCPISd4XKM6Q==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/form-utils': 0.20.0
+      '@zag-js/interact-outside': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
     dev: false
 
   /@zag-js/editable@0.30.0:
@@ -1322,8 +2508,24 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/element-rect@0.19.1:
+    resolution: {integrity: sha512-VIxSkvK9+8VMcm0TCKglgyOK3XELQK/vIVlCz+lY0nmR52+nL8ZDWnSB50fPiH4pu1awMoleyTPw/FfuaKhGXQ==}
+    dev: false
+
+  /@zag-js/element-rect@0.20.0:
+    resolution: {integrity: sha512-C3F2eZKdnzHZH/hy3nB/jPCl3KuJxSC9ze2wgXwwM8LnA2Okt/oP3m5lBbAcWbw5ZSVSZr8uzSHFB9pOp4NbmA==}
+    dev: false
+
   /@zag-js/element-rect@0.30.0:
     resolution: {integrity: sha512-u8SOqz1NK+RIAQEnILBK1bmC9rDpBaGqezzYqQf0Z30EE8CtkjVWsqONJurprzMqkORmqO9m1aSHc/SiLypeMg==}
+    dev: false
+
+  /@zag-js/element-size@0.19.1:
+    resolution: {integrity: sha512-OCaTwqEiiyy41FHs/s64zVNnU8Y/I4LVRF3oR0z3fx4QwMOVhp29RvXD4DTki5Fblv4kon/6yYI2TCbJrEBh/A==}
+    dev: false
+
+  /@zag-js/element-size@0.20.0:
+    resolution: {integrity: sha512-Z7eyIZLhkbTY862qHWetTP7hwz5ymW2Wwc0DuHZrT7lbEKLa6/CPHKmJV6BjDOH99n5jjdXS/MwFqCw4h20w/w==}
     dev: false
 
   /@zag-js/element-size@0.30.0:
@@ -1346,10 +2548,46 @@ packages:
     resolution: {integrity: sha512-IHyRZCEBRH3UltQhbkduDYmhvtHF3UDacyYfzBXfo0pBuhWn6Oob9oCihqdEkXnmXRBskS/KxzmMsK0GZxna4w==}
     dev: false
 
+  /@zag-js/form-utils@0.19.1:
+    resolution: {integrity: sha512-a7BFzL7jRF+IyG8BEB+ZT5wCrA3JpoNRDWuAyNXzRZFnN11v71UQ2ph1K7eaViH4wGTCUzvzKtrIL73y0GlMFQ==}
+    dependencies:
+      '@zag-js/mutation-observer': 0.19.1
+    dev: false
+
+  /@zag-js/form-utils@0.20.0:
+    resolution: {integrity: sha512-4yB8Qohx6pmvCpw2SFgK7hTPBT6KnXYTKKv1heyTnlL3RnTcGEiDYLCXxes0i2ud/44joAZ0XkaNeJ85oMZi4A==}
+    dependencies:
+      '@zag-js/mutation-observer': 0.20.0
+    dev: false
+
   /@zag-js/form-utils@0.30.0:
     resolution: {integrity: sha512-PSutqjx6kakpIOjo4tyqg9fs9l1Fiy8OQ3qHxY8zBuJnZfwE9CjeMaT9nHKixmIH+ISL14OFnRP8a28x70TIWA==}
     dependencies:
       '@zag-js/mutation-observer': 0.30.0
+    dev: false
+
+  /@zag-js/hover-card@0.19.1:
+    resolution: {integrity: sha512-lxMyNRF9D9yk+iDNbZg733m3CgXW9clQaGlkB6HrLLdU+S1B/5UDc2JikJIBdzRqzuXC90rjIQhGTIWxKOUlpw==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dismissable': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/popper': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/hover-card@0.20.0:
+    resolution: {integrity: sha512-M73+ey6+EuoVCPIjkNXXnmKznMBLE9fJPKebLDZAr03ux9SG03E9fFhXjmvmmi6AzZ5tauddRpeVXgr00pulLg==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dismissable': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/popper': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
     dev: false
 
   /@zag-js/hover-card@0.30.0:
@@ -1364,6 +2602,24 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/interact-outside@0.19.1:
+    resolution: {integrity: sha512-GwHXh6F4JcwyRb5hZkRZqON8fV04R/cq2Sbiy1XaCJb8ZdPs7fNNFle8A2hLM6dDuTLvmWJXWZJVoveQWMwcRA==}
+    dependencies:
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/tabbable': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/interact-outside@0.20.0:
+    resolution: {integrity: sha512-yJbqlSlhwRDkS4iZ2IENfDiJRX9YS25MqHUIySlK9mTO7cbPYPkruJWbbnXS+qogkJ8WIkGhExWT0I6znaXTvg==}
+    dependencies:
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/tabbable': 0.20.0
+      '@zag-js/utils': 0.20.0
+    dev: false
+
   /@zag-js/interact-outside@0.30.0:
     resolution: {integrity: sha512-yqmnzKZ2mAaOT4udQkTBgGFr3aBPwl/Ta69QVdc1ilDURDzRF77oqonzirJ65nqYQv+ykhiHGL5ltYlVzhz+rQ==}
     dependencies:
@@ -1373,10 +2629,50 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/live-region@0.19.1:
+    resolution: {integrity: sha512-htA5OJXrnU6xKL3jykzn1YdoWYxB+CZeUY4KWvCksJT7IFKl8ROJXgwhDJOdwFhoWPc4ktCBODm0j8tAn4HbhQ==}
+    dependencies:
+      '@zag-js/visually-hidden': 0.19.1
+    dev: false
+
+  /@zag-js/live-region@0.20.0:
+    resolution: {integrity: sha512-NxfBFkq2N+r6Z5xsIfWbB64E9AoUfIFL9LFisO9gMMdOFC4pFwgQVphLTHwE/VIJd8ekxPkaWaZa0skxxY+ppg==}
+    dependencies:
+      '@zag-js/visually-hidden': 0.20.0
+    dev: false
+
   /@zag-js/live-region@0.30.0:
     resolution: {integrity: sha512-c607D4nxybf/PiSgb/7KM1hl4ZBIvvO6gW5Q9ODJWJP963yWCA5xkBm/kMh1rbk0u7U4+SiUp2iZk25+CqJIOg==}
     dependencies:
       '@zag-js/visually-hidden': 0.30.0
+    dev: false
+
+  /@zag-js/menu@0.19.1:
+    resolution: {integrity: sha512-prFL3gygNaOr9lvpGB2JKEI8kNX/sAH4vPv1pxo+6PVXxQP3WmIPzhqv/3HKNplM0TQzMsSpmiDhvjqphhEAGg==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dismissable': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/popper': 0.19.1
+      '@zag-js/rect-utils': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/menu@0.20.0:
+    resolution: {integrity: sha512-6dv/g4ioiOAGXxu4QBS/idSKjAdi7JQpLwSm3h5i2Cc/jsH2vmlDM5DnO6BYmUT0gyzkQL61rQshKVh4FIV+kA==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dismissable': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/popper': 0.20.0
+      '@zag-js/rect-utils': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
     dev: false
 
   /@zag-js/menu@0.30.0:
@@ -1394,8 +2690,42 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/mutation-observer@0.19.1:
+    resolution: {integrity: sha512-u+YwwN40jJksXGt0Ab+CCw2bi8Yp68OVC2c8HILy1stsyc9awRE/Zodg2o/BeqiGSEL4Fi3smGhDsALYCYjyHg==}
+    dev: false
+
+  /@zag-js/mutation-observer@0.20.0:
+    resolution: {integrity: sha512-m1v+R53FzzlVmHrZKfx16/bvTekiCdWxCgCKYzBIW8rtpMFmy3J+JdYQv3YDP/GUlnr5ZR+wC4g8Vm1NKAfGKA==}
+    dev: false
+
   /@zag-js/mutation-observer@0.30.0:
     resolution: {integrity: sha512-E6gH0khXSznei88HdVQ1iRzvL1eldTPbOhfjx3HshaUbhAs+JXvdPglYhG7A9m7VCOGv6Z/ANBPQoabY9ilKmw==}
+    dev: false
+
+  /@zag-js/number-input@0.19.1:
+    resolution: {integrity: sha512-99EsBklNBKQKgnhf5jEsrLypHifPegb9RQSu/Vqxt6FiJjU7CQ3ud3NmSoDH+VfCKfofLfD5x0aLmpfwQbZHig==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/mutation-observer': 0.19.1
+      '@zag-js/number-utils': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/number-input@0.20.0:
+    resolution: {integrity: sha512-IVp4Pi9lEC5uG5FqTQmxn7M5rYWxAy+KTi9zN8YKrxuC98IVSATlzJHu654AAf38oG2Hff5ZWP4L+C88Stzbrw==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/mutation-observer': 0.20.0
+      '@zag-js/number-utils': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
     dev: false
 
   /@zag-js/number-input@0.30.0:
@@ -1413,12 +2743,48 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/number-utils@0.19.1:
+    resolution: {integrity: sha512-Rp1FwcbNUIdCL14POdNpCnWcUZ9x7V8TPSy7H8nvcVstrgBKq16RtXvDfyTFGx4gpmhzqgztmtUti8Ew2imdvg==}
+    dev: false
+
+  /@zag-js/number-utils@0.20.0:
+    resolution: {integrity: sha512-2CtBVjzdAOnBSaijUHKmuDKdzoL3DiC2szjz/PN1Z0fpxYXLMFMXuscRixCrRUhnBnYjJtKuMEsnfczJ/pixUw==}
+    dev: false
+
   /@zag-js/number-utils@0.30.0:
     resolution: {integrity: sha512-QhqSr3L913JrzMK8momRuTjn78fTXk3mnZSkX3KsAqlJ+MXsEC0vIKe0J6+wK/CHBYX/Y9VzzvpnLYlh24VkJQ==}
     dev: false
 
+  /@zag-js/numeric-range@0.19.1:
+    resolution: {integrity: sha512-Y6P/uchIL3k8c6H1cXpCJ7QojYtHqFOtL0no99pB+R99nathT+jZxR7FyJiCwOKz+fKEQzuZ0Ib8NDpKV1vSTw==}
+    dev: false
+
+  /@zag-js/numeric-range@0.20.0:
+    resolution: {integrity: sha512-ZXREiCSgew0yJkDsV9jQL/16KO5a/4RLWGUJsRfB+kXjaKpH3ic2RLDGM7kT/Taeh9TBws8Ex+1OkAF4P9fuFA==}
+    dev: false
+
   /@zag-js/numeric-range@0.30.0:
     resolution: {integrity: sha512-AkT0JxFEQhEGT0uanlm+Hbf2Uw6vBo//ocly97hR3/BQr9cjgbJtaR5kD9vJWDjLEy304VWoKAvwZjbtHvGIDQ==}
+    dev: false
+
+  /@zag-js/pagination@0.19.1:
+    resolution: {integrity: sha512-Ajkuf+OOp738e1RuxcsWRLplI5fCG0LTxCmMj00FJDasoulvdEl1cg41Lcmoiyh9hXQoU5T5qkqCD0zMBm7KNw==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/pagination@0.20.0:
+    resolution: {integrity: sha512-nZHIiVlY6gq3S7pQTQ8mXw0VDZ3tCJEUeyTcjMun2kc+zdaH5bKEFmJIIsNE5vs7AkSEN3pLfE/1Fge4KcsoGg==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
     dev: false
 
   /@zag-js/pagination@0.30.0:
@@ -1429,6 +2795,32 @@ packages:
       '@zag-js/dom-query': 0.30.0
       '@zag-js/types': 0.30.0
       '@zag-js/utils': 0.30.0
+    dev: false
+
+  /@zag-js/pin-input@0.19.1:
+    resolution: {integrity: sha512-1XGMjWb7X7idTrZfVMgQ6bKz9nuJOaVJCPP5EbWughPemFSSO+BE9ZoOysDQxypUEQnBSgvTgdjVuEvHpeGbsA==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/form-utils': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+      '@zag-js/visually-hidden': 0.19.1
+    dev: false
+
+  /@zag-js/pin-input@0.20.0:
+    resolution: {integrity: sha512-Pq/AY7HbNEgcZ8h22J6YRPRL48zrKDEnLz1rjI97F2SGb9mYsuhND42dHY912YgF/0o6TYoe0jvOgPJ8CWx+fQ==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/form-utils': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+      '@zag-js/visually-hidden': 0.20.0
     dev: false
 
   /@zag-js/pin-input@0.30.0:
@@ -1442,6 +2834,38 @@ packages:
       '@zag-js/types': 0.30.0
       '@zag-js/utils': 0.30.0
       '@zag-js/visually-hidden': 0.30.0
+    dev: false
+
+  /@zag-js/popover@0.19.1:
+    resolution: {integrity: sha512-9ar6d8CjWSzWESgCBpUieV6slybnVXCoBGJezJWzcZ7xJtzoqt18a+v48KqL/r4MCwHkP4rpI7Uhr7WoDi81Ww==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/aria-hidden': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dismissable': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/popper': 0.19.1
+      '@zag-js/remove-scroll': 0.19.1
+      '@zag-js/tabbable': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+      focus-trap: 7.5.2
+    dev: false
+
+  /@zag-js/popover@0.20.0:
+    resolution: {integrity: sha512-GkkdBD+VNraB3NN32iULg0KMpKu6ryE3lV4BUsC/4yIB7jpZZPdYU1qAJPC5WRHX1QpAbwlUDr5/8rAlshxx0A==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/aria-hidden': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dismissable': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/popper': 0.20.0
+      '@zag-js/remove-scroll': 0.20.0
+      '@zag-js/tabbable': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+      focus-trap: 7.5.2
     dev: false
 
   /@zag-js/popover@0.30.0:
@@ -1460,6 +2884,24 @@ packages:
       focus-trap: 7.5.4
     dev: false
 
+  /@zag-js/popper@0.19.1:
+    resolution: {integrity: sha512-DbyvJIA/zydtD4vRFek5kpDx60JW+JTO08RllCx5/qhg9hUb+Bn72ljNRO9Ev9y+bGCEFmrsHM1NNHGEKZQbAQ==}
+    dependencies:
+      '@floating-ui/dom': 1.5.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/element-rect': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/popper@0.20.0:
+    resolution: {integrity: sha512-/Jz3jtqyhh7uyQRAsdQhQd3K/PT51I0SLNVAQNXJcWfukjo3nGyrv8UhhSvqb65eJArYyRazWy5i9b7SKDk16g==}
+    dependencies:
+      '@floating-ui/dom': 1.5.2
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/element-rect': 0.20.0
+      '@zag-js/utils': 0.20.0
+    dev: false
+
   /@zag-js/popper@0.30.0:
     resolution: {integrity: sha512-113Kc5sLUL4y+PkZiSuGeEUDKkAaV8ZgwOX1iuRGcvUdhEbI0l5J+yo96QdRoIRVJiK+drKVAheUa+syy6AnXg==}
     dependencies:
@@ -1469,11 +2911,75 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/presence@0.19.1:
+    resolution: {integrity: sha512-oHf98d+a4l/JbYcjfr6NtyPcUjx2/bMOHhHUeAQkMSmgxKGGCgWKgCOmy+6uSxN1DbpWJ7rjJ7S88i5LWM1UhA==}
+    dependencies:
+      '@zag-js/core': 0.19.1
+      '@zag-js/types': 0.19.1
+    dev: false
+
+  /@zag-js/presence@0.20.0:
+    resolution: {integrity: sha512-px/rnvIGEYlz9jQjbBs9abzlZP19RxPMQ9thmPtVndMEbDq2Yem/ssgUwJcV5TDJL8rEsvX3hujCc1kI35GbMw==}
+    dependencies:
+      '@zag-js/core': 0.20.0
+      '@zag-js/types': 0.20.0
+    dev: false
+
   /@zag-js/presence@0.30.0:
     resolution: {integrity: sha512-LBHz9a9k5D7c6T9bdO+J2ZPgXZGciQ3g6blxM1rgutIiuShyF5na/A/umgjFxVlfiUQkevEcTc3RRXomj9WCqQ==}
     dependencies:
       '@zag-js/core': 0.30.0
       '@zag-js/types': 0.30.0
+    dev: false
+
+  /@zag-js/pressable@0.19.1:
+    resolution: {integrity: sha512-vFysM9V12d1lur1EN44pecmyikXlFxR8qCq3HNwdb0ovobVUXTM9JL6YleO63KyuiKZVU8QHyq2KEKGmfudYvg==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/text-selection': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/pressable@0.20.0:
+    resolution: {integrity: sha512-YmC6j95Bm+UkFWf/NTfW1qn14xDlj7EKMOdjykVdYrEV3r7g4GE3Dpl0MRfGp2GcjAPyiD8EtsGsYAcwLn65ww==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/text-selection': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+    dev: false
+
+  /@zag-js/radio-group@0.19.1:
+    resolution: {integrity: sha512-gyv7favAn49Ocj/QNwzQleqoJ7YnBtJhvI4Lio5sOiF+TiBuzjody6suaTcCpkYuumtXXMCHN7zFEjaKVIa0jA==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/element-rect': 0.19.1
+      '@zag-js/form-utils': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+      '@zag-js/visually-hidden': 0.19.1
+    dev: false
+
+  /@zag-js/radio-group@0.20.0:
+    resolution: {integrity: sha512-fQ5+tqPeWCqPwqCC7Ye4USo3tIbyW7Dgh35NJVhMHyLKzkEGrazBLrvbZWqF+uLZIcDZdyFGu6QU13S9sgKGoA==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/element-rect': 0.20.0
+      '@zag-js/form-utils': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+      '@zag-js/visually-hidden': 0.20.0
     dev: false
 
   /@zag-js/radio-group@0.30.0:
@@ -1489,6 +2995,60 @@ packages:
       '@zag-js/visually-hidden': 0.30.0
     dev: false
 
+  /@zag-js/range-slider@0.19.1:
+    resolution: {integrity: sha512-d6yAFWa5riQWi4M0djZcgK8k+JxW+Drh8LujS0SbF8E/lKZEiuhzDX2WcuCGayX5gqfLPetkHzo+v9F7rn2MIA==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/element-size': 0.19.1
+      '@zag-js/form-utils': 0.19.1
+      '@zag-js/numeric-range': 0.19.1
+      '@zag-js/slider': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/range-slider@0.20.0:
+    resolution: {integrity: sha512-w74Fnb98JuRrIpSbPFs0mtrVoL1HhKVz6Vd1IaBwjKe7Dr22DzNayBzv++CaHGnMC5Cw8DmgTmCQPdpvxhaKvg==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/element-size': 0.20.0
+      '@zag-js/form-utils': 0.20.0
+      '@zag-js/numeric-range': 0.20.0
+      '@zag-js/slider': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+    dev: false
+
+  /@zag-js/rating-group@0.19.1:
+    resolution: {integrity: sha512-wOvGjbfAFD8oeoEkBwgP/1VHPUPKoL0lT/oFm3nELjDZctCH4i4sqvaP66sgpekzhEQ+pXTpQbA8q/g4Ws5TqA==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/form-utils': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/rating-group@0.20.0:
+    resolution: {integrity: sha512-hjZx+LEPjSIKCAT2+Vseg+MJHqS9bbWGE6CmsBGbOBFSxoamAPH3pOo012s8JzsEWYODB0uui5SGToi/xWbAPw==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/form-utils': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+    dev: false
+
   /@zag-js/rating-group@0.30.0:
     resolution: {integrity: sha512-y3d1OFwXdorGv/bj6hraK5v1gYtpTk5ZXK6w01Ho3gWRSq9jhCZ5XgHWuMUHP7OaYJLw+XkvjhsWwFuIIngB3Q==}
     dependencies:
@@ -1499,6 +3059,20 @@ packages:
       '@zag-js/form-utils': 0.30.0
       '@zag-js/types': 0.30.0
       '@zag-js/utils': 0.30.0
+    dev: false
+
+  /@zag-js/react@0.19.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-FGFMqb4SgT9GDDgr9Cpan48T81JOTS3xyY5TV7b+aZFSObw657XlsEefCB38DvEc8NgOxhPPy+FBg+tQVGG62w==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+    dependencies:
+      '@zag-js/core': 0.19.1
+      '@zag-js/store': 0.19.1
+      '@zag-js/types': 0.19.1
+      proxy-compare: 2.5.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@zag-js/react@0.30.0(react-dom@18.2.0)(react@18.2.0):
@@ -1515,14 +3089,70 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@zag-js/rect-utils@0.19.1:
+    resolution: {integrity: sha512-iVezg79cIAXinnHd0qdxbXHFE3K0YcdE56Yg0WhH5eekHOKL4Y/kCrXFe/YnTt7FinRTH9RNXiWi/dbWrw0WNw==}
+    dev: false
+
+  /@zag-js/rect-utils@0.20.0:
+    resolution: {integrity: sha512-nS5nMkjcf1GjI4e83kc8588qzsYTUz7Yzs+/sz43AgEOrHTUdDa17UUWwZqfpMtn8u0F/X09ppEQSW4QZf77tg==}
+    dev: false
+
   /@zag-js/rect-utils@0.30.0:
     resolution: {integrity: sha512-Wr5VEyGmvYPsqnkixQiGRyBoLMXIUheGd88Q/9aUlivr7P2Omq8RQKl4PtWZUU8Th/FXJ58ardaCUKeymNsnnw==}
+    dev: false
+
+  /@zag-js/remove-scroll@0.19.1:
+    resolution: {integrity: sha512-VUw7WsdojpN/l6NtmkmeLr/o8/duYRGGgrnBJmxjND0u0QXrDI+VKCrVXfyr7Fu7APZggY2YVE2IXJi7JbwcfA==}
+    dependencies:
+      '@zag-js/dom-query': 0.19.1
+    dev: false
+
+  /@zag-js/remove-scroll@0.20.0:
+    resolution: {integrity: sha512-e1Qdumgd+dDoK8gtk+eIoWGLtztCZzgIvFRgVBB9HxDzCRAUqrCi2fiw8ofF9glLSNgXSCCRHtl55g/ueG6H/g==}
+    dependencies:
+      '@zag-js/dom-query': 0.20.0
     dev: false
 
   /@zag-js/remove-scroll@0.30.0:
     resolution: {integrity: sha512-FM4rja17VXfuUb8CznVH6rrI7cgN1Ij1Ywco58EY3dfRxpGJeR3euFdJJ7YIFct2HBASC9/BnapyQN0DbtnMVA==}
     dependencies:
       '@zag-js/dom-query': 0.30.0
+    dev: false
+
+  /@zag-js/select@0.19.1:
+    resolution: {integrity: sha512-kzn2WdB4VOYmExG7GC6FX+h+QnsgJTw1yNGkSxk1PFAvsiS73DBjMsxpAU+Z2/4SHHhNTcM/OkgzvXsTJcZsFQ==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/collection': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dismissable': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/form-utils': 0.19.1
+      '@zag-js/mutation-observer': 0.19.1
+      '@zag-js/popper': 0.19.1
+      '@zag-js/tabbable': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+      '@zag-js/visually-hidden': 0.19.1
+    dev: false
+
+  /@zag-js/select@0.20.0:
+    resolution: {integrity: sha512-F9TYrK34ImWzxYJ4Xm0+6xRUHi1N+gRwpSDi1mAKqiVMgA8bPC1cYY+RgdxzWFvPnc6fAEYMdlD8h1FlH4RW+Q==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/collection': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dismissable': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/form-utils': 0.20.0
+      '@zag-js/mutation-observer': 0.20.0
+      '@zag-js/popper': 0.20.0
+      '@zag-js/tabbable': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+      '@zag-js/visually-hidden': 0.20.0
     dev: false
 
   /@zag-js/select@0.30.0:
@@ -1543,6 +3173,34 @@ packages:
       '@zag-js/visually-hidden': 0.30.0
     dev: false
 
+  /@zag-js/slider@0.19.1:
+    resolution: {integrity: sha512-Njc+v09CtMbJlbk8q/dMIoAhgVmYxKKwIcyIz/PGmHQw6G6z9sZ2lS17qkeZObj/EIKtyQhw7rXXJ+T895w6wQ==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/element-size': 0.19.1
+      '@zag-js/form-utils': 0.19.1
+      '@zag-js/numeric-range': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/slider@0.20.0:
+    resolution: {integrity: sha512-ZLOBPB47lSGttzr1ozbgEr7zU37HY2KUHu85vbn5AJxvlGkfcYQCn9Qb53WNcE/XAiXP9WNhmkaIftkVcY2bFA==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/element-size': 0.20.0
+      '@zag-js/form-utils': 0.20.0
+      '@zag-js/numeric-range': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+    dev: false
+
   /@zag-js/slider@0.30.0:
     resolution: {integrity: sha512-yF29PHBUPTxhqQaYcKurzr8CWTcuy6RBS4ulCdDnlo0nYbMBuEMoXFOItW7vOzh5wZuLf/MdAwxaOn3xWWSN/A==}
     dependencies:
@@ -1557,6 +3215,30 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/splitter@0.19.1:
+    resolution: {integrity: sha512-5fa2chmPUAAkMF0xTWKJfkCBamjjFRU3YQwXR8GRi1iqVi58e0MrmEoKdJ9v3XCw+X18tua5YszzRWttZdJXwQ==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/number-utils': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/splitter@0.20.0:
+    resolution: {integrity: sha512-gYNNBdu73xmrDe1wuRNibaY8TCiml//rIDx6jCwhjohQsox5B30OXq9E0dwAMmCIII/XL2qvR4D+1rb/P27arA==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/number-utils': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+    dev: false
+
   /@zag-js/splitter@0.30.0:
     resolution: {integrity: sha512-1gVLpGe/7/mMwMvHHt9IdqEpZuXKJNrQcG4fV/SA5WhWJ34capFHrM46WpO7gyWbwJCUjAaI4JPJkkab9ebkeA==}
     dependencies:
@@ -1569,10 +3251,46 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/store@0.19.1:
+    resolution: {integrity: sha512-u0Nn6UdrSSUO8Slj/ry3du24PzIfkMrdXY5rmpTK9+6riSSgl46sQEKhn8rxtk1d4q7psGK8Og0KlEcfdvqZTA==}
+    dependencies:
+      proxy-compare: 2.5.1
+    dev: false
+
+  /@zag-js/store@0.20.0:
+    resolution: {integrity: sha512-/UT+m7TsJ+fv6TFm2gDFf6H8nF9ynmdGfQnrm1BmtEMXtSkt9Vxmo+1DMeawzzULaKLXNX5ghwVZqFqInVZ8gA==}
+    dependencies:
+      proxy-compare: 2.5.1
+    dev: false
+
   /@zag-js/store@0.30.0:
     resolution: {integrity: sha512-AMvsP8WC2UTYiRVtWTfCm3MJzrNa32GfsmgMdjKlxzTGSlVxKAJcfEHwUWY0EJD58UfAvjKFL3KATIJPrYHqtA==}
     dependencies:
       proxy-compare: 2.5.1
+    dev: false
+
+  /@zag-js/switch@0.19.1:
+    resolution: {integrity: sha512-rtK+q8iV8n8ZosCTat+Zq4gE3ODE/xmw1i5UGdTIWv0aJjp/diq0lNaUobndRAaYEhxA7jNiV5utPlDiB6LbAA==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/form-utils': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+      '@zag-js/visually-hidden': 0.19.1
+    dev: false
+
+  /@zag-js/switch@0.20.0:
+    resolution: {integrity: sha512-vBvBrRB67vGvESWyaQjj1xYWS0CTqOGm7kPh/kicQALdM3f+Dn8vFyUpTbVgro57doXwN2GMzrmOtZY5nB0s1g==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/form-utils': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+      '@zag-js/visually-hidden': 0.20.0
     dev: false
 
   /@zag-js/switch@0.30.0:
@@ -1587,10 +3305,48 @@ packages:
       '@zag-js/visually-hidden': 0.30.0
     dev: false
 
+  /@zag-js/tabbable@0.19.1:
+    resolution: {integrity: sha512-tiVOTjUFbcWzFrz1ObcTfdb6ZnOM8Xr/eOYZITlWxNbWNQSNZk64QIjSGylQF3pzm2iQgPxYI1qEljiyayWBJQ==}
+    dependencies:
+      '@zag-js/dom-query': 0.19.1
+    dev: false
+
+  /@zag-js/tabbable@0.20.0:
+    resolution: {integrity: sha512-7RxaosWb5Wl+owUBFKjaZX9ytIcu4s4bapUdZrp6irmGefnPUmyxiH3BJGGTFu4V0GsHDDXHWNnQdO9pKWFhTw==}
+    dependencies:
+      '@zag-js/dom-query': 0.20.0
+    dev: false
+
   /@zag-js/tabbable@0.30.0:
     resolution: {integrity: sha512-II9a+12qAes3Aq0ePlPt7NoRgoJERIgkxfVz12yolFHfDcViGvV34569hUkX9UTTLsE6pDLGpdbLntKX3YILcg==}
     dependencies:
       '@zag-js/dom-query': 0.30.0
+    dev: false
+
+  /@zag-js/tabs@0.19.1:
+    resolution: {integrity: sha512-eNCHD7zMV2q7yOD7M7/St6nfZykQ52klf4yqyLNpCdSm577zlSGawRDgiipMQko7Wz1Im0OPDOontKKQ8QncEw==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/element-rect': 0.19.1
+      '@zag-js/tabbable': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/tabs@0.20.0:
+    resolution: {integrity: sha512-dCCH2d0r7r1L4RE1+r3KQb1MDy2dfvmUoctow/GnN08BJXS45A4yx4YpsYcl1E9rUD21bJdQiXBbhqEuzM1tUA==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/element-rect': 0.20.0
+      '@zag-js/tabbable': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
     dev: false
 
   /@zag-js/tabs@0.30.0:
@@ -1604,6 +3360,36 @@ packages:
       '@zag-js/tabbable': 0.30.0
       '@zag-js/types': 0.30.0
       '@zag-js/utils': 0.30.0
+    dev: false
+
+  /@zag-js/tags-input@0.19.1:
+    resolution: {integrity: sha512-oyhRdpT7eDrE4iC0axT0FC+rjUSehqYXFaTElXIJbYVOtEJrvdErejK7+jHYQ93I5oBap3UMvAvre/+RKnJVAQ==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/auto-resize': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/form-utils': 0.19.1
+      '@zag-js/interact-outside': 0.19.1
+      '@zag-js/live-region': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/tags-input@0.20.0:
+    resolution: {integrity: sha512-VBp0GhkBi5VGW56W3K/CbxqMpG85IF8sNew4xzHT0GvT2sSPdL0DXcaeIoaks2IlmFIWdVAgLpR2te8ZxCTfiA==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/auto-resize': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/form-utils': 0.20.0
+      '@zag-js/interact-outside': 0.20.0
+      '@zag-js/live-region': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
     dev: false
 
   /@zag-js/tags-input@0.30.0:
@@ -1621,10 +3407,44 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/text-selection@0.19.1:
+    resolution: {integrity: sha512-8FDFDJzxefENFzbejuTfkODz6MVVR8Oq3rddtztM7nai8taJ8vPccXAmOSYcqjAjItB0kc2UqLVFYIIpczTn3w==}
+    dependencies:
+      '@zag-js/dom-query': 0.19.1
+    dev: false
+
+  /@zag-js/text-selection@0.20.0:
+    resolution: {integrity: sha512-xME+OoMK7EImjNRhyTVU5wg2rOOVScgh4eb91w0Q+qzh9i4r6YfNTqxdGMjhqJwWvjUuSJGPzluhCKBGuZ57Lg==}
+    dependencies:
+      '@zag-js/dom-query': 0.20.0
+    dev: false
+
   /@zag-js/text-selection@0.30.0:
     resolution: {integrity: sha512-bfZ9Mzk0cbY3BH26FvMv10l9+tOIHj9ZiM6D/oun9WQ1Pcn9QOaBA5iS9F5rMfhVSVBgjrYOxj4v3U2GtF3Piw==}
     dependencies:
       '@zag-js/dom-query': 0.30.0
+    dev: false
+
+  /@zag-js/toast@0.19.1:
+    resolution: {integrity: sha512-6RVHkNTEg2t3xKttxcJTY+3ydSC8eRzGzI+r03qCmJGHVD1Eqw+r8eZNcm0LhlurihDbjPtOf/n504kSFotArQ==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/toast@0.20.0:
+    resolution: {integrity: sha512-oxFNfKoEoHn/ULrV5ZtjQu6t5j+8kcVjRGjxr1Z+JPylC/9JVKxsetnfuUyAzzh+sABcqPFVi20pwP6fupzQRw==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
     dev: false
 
   /@zag-js/toast@0.30.0:
@@ -1638,6 +3458,28 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/toggle-group@0.19.1:
+    resolution: {integrity: sha512-/l+moOIfYdQ0opEX6r7z+TDnflCJfGXqPsebK1UQtt2QW1WwMXndMlaxKZqBA70WgtI9xRa6ssKz54azC7d5QA==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/toggle-group@0.20.0:
+    resolution: {integrity: sha512-QDXfjR9+8GSQpHN8idv2GDuyG+zga5vqlQjO6u6LSu1BZZw9z0XtZRU/5tb3NBsCIxV+3mFk6/bPNghodmqS9A==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
+    dev: false
+
   /@zag-js/toggle-group@0.30.0:
     resolution: {integrity: sha512-D+y/DdcKeiIrUDWvOCFIm7mw/aipQXkXbTavZrIrJyfJixqr0yVAOeI6R76jkPhP18hLP5aykpVba3o5irA8NA==}
     dependencies:
@@ -1647,6 +3489,30 @@ packages:
       '@zag-js/dom-query': 0.30.0
       '@zag-js/types': 0.30.0
       '@zag-js/utils': 0.30.0
+    dev: false
+
+  /@zag-js/tooltip@0.19.1:
+    resolution: {integrity: sha512-UJaOLo6aVbOoS2XoO+n8wECTg2pa50PJ71IMAfPeMbpm79/UfL9ZO2Bu3j/0CU+F9R+4I08LsN63AwuLac1f3Q==}
+    dependencies:
+      '@zag-js/anatomy': 0.19.1
+      '@zag-js/core': 0.19.1
+      '@zag-js/dom-event': 0.19.1
+      '@zag-js/dom-query': 0.19.1
+      '@zag-js/popper': 0.19.1
+      '@zag-js/types': 0.19.1
+      '@zag-js/utils': 0.19.1
+    dev: false
+
+  /@zag-js/tooltip@0.20.0:
+    resolution: {integrity: sha512-HT6U76mv2kDYRWvdk8mx80saIumoA/Lom5l3ZtAzwxpLF0X+43y35TwjJL8etQPdYFy+tYqGKVCn59jnFqNong==}
+    dependencies:
+      '@zag-js/anatomy': 0.20.0
+      '@zag-js/core': 0.20.0
+      '@zag-js/dom-event': 0.20.0
+      '@zag-js/dom-query': 0.20.0
+      '@zag-js/popper': 0.20.0
+      '@zag-js/types': 0.20.0
+      '@zag-js/utils': 0.20.0
     dev: false
 
   /@zag-js/tooltip@0.30.0:
@@ -1661,14 +3527,42 @@ packages:
       '@zag-js/utils': 0.30.0
     dev: false
 
+  /@zag-js/types@0.19.1:
+    resolution: {integrity: sha512-F+oHigTVrFfldTMYDHKxFgYI7cgq4/nLHf7+7mvBqX0g7iTscIYZIyhHJcseGUKx471JU1TzYaemUCHFlEfszQ==}
+    dependencies:
+      csstype: 3.1.2
+    dev: false
+
+  /@zag-js/types@0.20.0:
+    resolution: {integrity: sha512-bem7RnD98TjXmkuawLQpuyfRtutvSFucikX5uZrxKhOsvfvNlfanYrYmbkgEcVvj4qblv8qpG2wse+qw8tBIjg==}
+    dependencies:
+      csstype: 3.1.2
+    dev: false
+
   /@zag-js/types@0.30.0:
     resolution: {integrity: sha512-e3BNMe1/OvpzDyzKEk6n6iad8ntbFETbKANsjsAO0m7pwXN0MpPA+P9EzwafRuTEFycTCAV05VWc3zaeAkDpPg==}
     dependencies:
       csstype: 3.1.2
     dev: false
 
+  /@zag-js/utils@0.19.1:
+    resolution: {integrity: sha512-xe1ngtnNztftZVXd9rs9vfwxfmweeIAyb+HiZeHV2FHAwbTlaTIfwYWO0vQgOx2hhVU2iKsLHxoKbcMqIGGetQ==}
+    dev: false
+
+  /@zag-js/utils@0.20.0:
+    resolution: {integrity: sha512-AnoDjl68jBaZE1gnO5E3WvQwyHK38Fdnd4xEpZ4cz0uLimWIUUmf7DL79DlL3Pu/ACzJ9WeeDdAQFmdYeqs1xQ==}
+    dev: false
+
   /@zag-js/utils@0.30.0:
     resolution: {integrity: sha512-wWBz1qMM2WuRQWrA4zTWlSdRFmTbPsjCHDEu5tI4b/rzX0J2uZ1SDH2xwt89XA+JXmXu/Aol5RhYkUb3wLzjiQ==}
+    dev: false
+
+  /@zag-js/visually-hidden@0.19.1:
+    resolution: {integrity: sha512-oYByHllhauPiW3X3qpt4giERqjtDxvzppJowl9b7wmGqHJ810cc6r01MWwQm+OGWjvMeZWS/QPN1UAPbYPvpPw==}
+    dev: false
+
+  /@zag-js/visually-hidden@0.20.0:
+    resolution: {integrity: sha512-TrAoiymPNoBgx1f9pOyaM6j0xlxBgGDX209WZvphJDg4616S8KICUSqmC2u0c6gtahkypxGdYDfyj6I83hVuzQ==}
     dev: false
 
   /@zag-js/visually-hidden@0.30.0:
@@ -1687,6 +3581,12 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  /acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: false
+
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
     dependencies:
@@ -1695,6 +3595,11 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
     dev: true
+
+  /ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+    dev: false
 
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1729,7 +3634,6 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-    dev: true
 
   /arch@2.2.0:
     resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
@@ -1834,6 +3738,22 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
+  /autoprefixer@10.4.15(postcss@8.4.31):
+    resolution: {integrity: sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      browserslist: 4.22.1
+      caniuse-lite: 1.0.30001561
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.0.0
+      postcss: 8.4.31
+      postcss-value-parser: 4.2.0
+    dev: false
+
   /autoprefixer@10.4.16(postcss@8.4.31):
     resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1874,7 +3794,6 @@ packages:
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
-    dev: true
 
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -1893,7 +3812,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
-    dev: true
 
   /browserslist@4.22.1:
     resolution: {integrity: sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==}
@@ -1904,13 +3822,35 @@ packages:
       electron-to-chromium: 1.4.579
       node-releases: 2.0.13
       update-browserslist-db: 1.0.13(browserslist@4.22.1)
-    dev: true
+
+  /browserslist@4.22.3:
+    resolution: {integrity: sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001581
+      electron-to-chromium: 1.4.648
+      node-releases: 2.0.14
+      update-browserslist-db: 1.0.13(browserslist@4.22.3)
+    dev: false
+
+  /bundle-n-require@1.0.1:
+    resolution: {integrity: sha512-gItLuU8M0uI7bcHim+wM+Y1bY9eG7j3XbGcU3ZCqsrJLj4ZIHhchHWQ1luL9c4P8yPNLC9Jkwbct/EgR0u/dzQ==}
+    dependencies:
+      esbuild: 0.17.19
+      node-eval: 2.0.0
+    dev: false
 
   /busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
     dependencies:
       streamsearch: 1.1.0
+    dev: false
+
+  /cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
     dev: false
 
   /call-bind@1.0.5:
@@ -1935,8 +3875,21 @@ packages:
     resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
     dev: false
 
+  /caniuse-api@3.0.0:
+    resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
+    dependencies:
+      browserslist: 4.22.3
+      caniuse-lite: 1.0.30001561
+      lodash.memoize: 4.1.2
+      lodash.uniq: 4.5.0
+    dev: false
+
   /caniuse-lite@1.0.30001561:
     resolution: {integrity: sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==}
+
+  /caniuse-lite@1.0.30001581:
+    resolution: {integrity: sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==}
+    dev: false
 
   /ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1988,7 +3941,6 @@ packages:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /classnames@2.3.2:
     resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}
@@ -2009,6 +3961,10 @@ packages:
   /clsx@2.0.0:
     resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
     engines: {node: '>=6'}
+    dev: false
+
+  /code-block-writer@12.0.0:
+    resolution: {integrity: sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==}
     dev: false
 
   /collapse-white-space@2.1.0:
@@ -2035,6 +3991,10 @@ packages:
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
+
+  /colorjs.io@0.4.5:
+    resolution: {integrity: sha512-yCtUNCmge7llyfd/Wou19PMAcf5yC3XXhgFoAh6zsO2pGswhUPBaaUh8jzgHnXtXuZyFKzXZNAnyF5i+apICow==}
+    dev: false
 
   /comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -2068,6 +4028,11 @@ packages:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
+  /core-js-pure@3.35.1:
+    resolution: {integrity: sha512-zcIdi/CL3MWbBJYo5YCeVAAx+Sy9yJE9I3/u9LkFABwbeaPhTMRWraM8mYFp9jW5Z50hOy7FVzCc8dCrpZqtIQ==}
+    requiresBuild: true
+    dev: false
+
   /cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
     dependencies:
@@ -2097,6 +4062,13 @@ packages:
       which: 2.0.2
     dev: true
 
+  /crosspath@2.0.0:
+    resolution: {integrity: sha512-ju88BYCQ2uvjO2bR+SsgLSTwTSctU+6Vp2ePbKPgSCZyy4MWZxYsT738DlKVRE5utUjobjPRm1MkTYKJxCmpTA==}
+    engines: {node: '>=14.9.0'}
+    dependencies:
+      '@types/node': 17.0.45
+    dev: false
+
   /css-color-keywords@1.0.0:
     resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
     engines: {node: '>=4'}
@@ -2114,7 +4086,15 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
+
+  /cssnano-utils@4.0.1(postcss@8.4.31):
+    resolution: {integrity: sha512-6qQuYDqsGoiXssZ3zct6dcMxiqfT6epy7x4R0TQJadd4LWO3sPR6JH6ZByOvVLoZ6EdwPGgd7+DR1EmX3tiXQQ==}
+    engines: {node: ^14 || ^16 || >=18.0}
+    peerDependencies:
+      postcss: ^8.4.31
+    dependencies:
+      postcss: 8.4.31
+    dev: false
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
@@ -2517,13 +4497,43 @@ packages:
       esutils: 2.0.3
     dev: true
 
+  /dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+    dev: false
+
+  /domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+    dev: false
+
+  /domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.3.0
+    dev: false
+
   /dompurify@3.0.6:
     resolution: {integrity: sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w==}
     dev: false
 
+  /domutils@3.1.0:
+    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+    dev: false
+
   /electron-to-chromium@1.4.579:
     resolution: {integrity: sha512-bJKvA+awBIzYR0xRced7PrQuRIwGQPpo6ZLP62GAShahU9fWpsNN2IP6BSP1BLDDSbxvBVRGAMWlvVVq3npmLA==}
-    dev: true
+
+  /electron-to-chromium@1.4.648:
+    resolution: {integrity: sha512-EmFMarXeqJp9cUKu/QEciEApn0S/xRcpZWuAm32U7NgoZCimjsilKXHRO9saeEW55eHZagIDg6XTUOv32w9pjg==}
+    dev: false
 
   /elkjs@0.8.2:
     resolution: {integrity: sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==}
@@ -2622,10 +4632,39 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
+  /esbuild@0.17.19:
+    resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.17.19
+      '@esbuild/android-arm64': 0.17.19
+      '@esbuild/android-x64': 0.17.19
+      '@esbuild/darwin-arm64': 0.17.19
+      '@esbuild/darwin-x64': 0.17.19
+      '@esbuild/freebsd-arm64': 0.17.19
+      '@esbuild/freebsd-x64': 0.17.19
+      '@esbuild/linux-arm': 0.17.19
+      '@esbuild/linux-arm64': 0.17.19
+      '@esbuild/linux-ia32': 0.17.19
+      '@esbuild/linux-loong64': 0.17.19
+      '@esbuild/linux-mips64el': 0.17.19
+      '@esbuild/linux-ppc64': 0.17.19
+      '@esbuild/linux-riscv64': 0.17.19
+      '@esbuild/linux-s390x': 0.17.19
+      '@esbuild/linux-x64': 0.17.19
+      '@esbuild/netbsd-x64': 0.17.19
+      '@esbuild/openbsd-x64': 0.17.19
+      '@esbuild/sunos-x64': 0.17.19
+      '@esbuild/win32-arm64': 0.17.19
+      '@esbuild/win32-ia32': 0.17.19
+      '@esbuild/win32-x64': 0.17.19
+    dev: false
+
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
-    dev: true
 
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -2819,6 +4858,10 @@ packages:
       '@types/unist': 3.0.2
     dev: false
 
+  /estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: false
+
   /estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
     dependencies:
@@ -2867,7 +4910,6 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
-    dev: true
 
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -2881,7 +4923,6 @@ packages:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
       reusify: 1.0.4
-    dev: true
 
   /fault@2.0.1:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
@@ -2896,12 +4937,28 @@ packages:
       flat-cache: 3.2.0
     dev: true
 
+  /file-size@1.0.0:
+    resolution: {integrity: sha512-tLIdonWTpABkU6Axg2yGChYdrOsy4V8xcm0IcyAP8fSsu6jiXLm5pgs083e4sq5fzNRZuAYolUbZyYmPvCKfwQ==}
+    dev: false
+
+  /filesize@10.1.0:
+    resolution: {integrity: sha512-GTLKYyBSDz3nPhlLVPjPWZCnhkd9TrrRArNcy8Z+J2cqScB7h2McAzR6NBX6nYOoWafql0roY8hrocxnZBv9CQ==}
+    engines: {node: '>= 10.4.0'}
+    dev: false
+
   /fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
-    dev: true
+
+  /find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+    dev: false
 
   /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -2909,7 +4966,13 @@ packages:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
-    dev: true
+
+  /find-yarn-workspace-root2@1.2.16:
+    resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
+    dependencies:
+      micromatch: 4.0.5
+      pkg-dir: 4.2.0
+    dev: false
 
   /flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
@@ -2926,6 +4989,12 @@ packages:
 
   /flexsearch@0.7.31:
     resolution: {integrity: sha512-XGozTsMPYkm+6b5QL3Z9wQcJjNYxp0CYn3U1gO7dwD6PAqU1SVWZxI9CCg3z+ml3YfqdPnrBehaBrnH2AGKbNA==}
+    dev: false
+
+  /focus-trap@7.5.2:
+    resolution: {integrity: sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==}
+    dependencies:
+      tabbable: 6.2.0
     dev: false
 
   /focus-trap@7.5.4:
@@ -2951,7 +5020,33 @@ packages:
 
   /fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
-    dev: true
+
+  /framer-motion@10.18.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-oGlDh1Q1XqYPksuTD/usb0I70hq95OUzmL9+6Zd+Hs4XV0oaISBa/UUMSjYiq6m8EUF32132mOJ8xVZS+I0S6w==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tslib: 2.6.2
+    optionalDependencies:
+      '@emotion/is-prop-valid': 0.8.8
+    dev: false
+
+  /fs-extra@11.1.1:
+    resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
+    engines: {node: '>=14.14'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+    dev: false
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -2962,7 +5057,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /function-bind@1.1.2:
@@ -3014,14 +5108,12 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.3
-    dev: true
 
   /glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
     dependencies:
       is-glob: 4.0.3
-    dev: true
 
   /glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
@@ -3077,6 +5169,30 @@ packages:
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
+
+  /graphql-tag@2.12.6(graphql@16.8.1):
+    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      graphql: 16.8.1
+      tslib: 2.6.2
+    dev: false
+
+  /graphql-ws@5.14.3(graphql@16.8.1):
+    resolution: {integrity: sha512-F/i2xNIVbaEF2xWggID0X/UZQa2V8kqKDPO8hwmu53bVOcTL7uNkxnexeEgSCVxYBQUTUNEI8+e4LO1FOhKPKQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: '>=0.11 <=16'
+    dependencies:
+      graphql: 16.8.1
+    dev: false
+
+  /graphql@16.8.1:
+    resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: false
 
   /gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
@@ -3169,6 +5285,18 @@ packages:
       vfile-message: 4.0.2
     dev: false
 
+  /hast-util-from-parse5@7.1.2:
+    resolution: {integrity: sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==}
+    dependencies:
+      '@types/hast': 2.3.8
+      '@types/unist': 2.0.10
+      hastscript: 7.2.0
+      property-information: 6.4.0
+      vfile: 5.3.7
+      vfile-location: 4.1.0
+      web-namespaces: 2.0.1
+    dev: false
+
   /hast-util-from-parse5@8.0.1:
     resolution: {integrity: sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==}
     dependencies:
@@ -3188,10 +5316,32 @@ packages:
       '@types/hast': 3.0.3
     dev: false
 
+  /hast-util-parse-selector@3.1.1:
+    resolution: {integrity: sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==}
+    dependencies:
+      '@types/hast': 2.3.8
+    dev: false
+
   /hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
     dependencies:
       '@types/hast': 3.0.3
+    dev: false
+
+  /hast-util-raw@7.2.3:
+    resolution: {integrity: sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==}
+    dependencies:
+      '@types/hast': 2.3.8
+      '@types/parse5': 6.0.3
+      hast-util-from-parse5: 7.1.2
+      hast-util-to-parse5: 7.1.0
+      html-void-elements: 2.0.1
+      parse5: 6.0.1
+      unist-util-position: 4.0.4
+      unist-util-visit: 4.1.2
+      vfile: 5.3.7
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
     dev: false
 
   /hast-util-raw@9.0.1:
@@ -3274,6 +5424,17 @@ packages:
       - supports-color
     dev: false
 
+  /hast-util-to-parse5@7.1.0:
+    resolution: {integrity: sha512-YNRgAJkH2Jky5ySkIqFXTQiaqcAtJyVE+D5lkN6CdtOqrnkLfGYYrEcKuHOJZlp+MwjSwuD3fZuawI+sic/RBw==}
+    dependencies:
+      '@types/hast': 2.3.8
+      comma-separated-tokens: 2.0.3
+      property-information: 6.4.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+    dev: false
+
   /hast-util-to-parse5@8.0.0:
     resolution: {integrity: sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==}
     dependencies:
@@ -3295,10 +5456,24 @@ packages:
       unist-util-find-after: 5.0.0
     dev: false
 
+  /hast-util-whitespace@2.0.1:
+    resolution: {integrity: sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==}
+    dev: false
+
   /hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
     dependencies:
       '@types/hast': 3.0.3
+    dev: false
+
+  /hastscript@7.2.0:
+    resolution: {integrity: sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==}
+    dependencies:
+      '@types/hast': 2.3.8
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 3.1.1
+      property-information: 6.4.0
+      space-separated-tokens: 2.0.2
     dev: false
 
   /hastscript@8.0.0:
@@ -3315,8 +5490,54 @@ packages:
     resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
     dev: false
 
+  /hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+    dependencies:
+      react-is: 16.13.1
+    dev: false
+
+  /hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+    dev: false
+
+  /html-dom-parser@3.1.7:
+    resolution: {integrity: sha512-cDgNF4YgF6J3H+d9mcldGL19p0GzVdS3iGuDNzYWQpU47q3+IRM85X3Xo07E+nntF4ek4s78A9V24EwxlPTjig==}
+    dependencies:
+      domhandler: 5.0.3
+      htmlparser2: 8.0.2
+    dev: false
+
+  /html-react-parser@3.0.16(react@18.2.0):
+    resolution: {integrity: sha512-ysQZtRFPcg+McVb4B05oNWSnqM14zagpvTgGcI5e1/BvCl38YwzWzKibrbBmXeemg70olN1bAoeixo7o06G5Eg==}
+    peerDependencies:
+      react: 0.14 || 15 || 16 || 17 || 18
+    dependencies:
+      domhandler: 5.0.3
+      html-dom-parser: 3.1.7
+      react: 18.2.0
+      react-property: 2.0.0
+      style-to-js: 1.1.3
+    dev: false
+
+  /html-void-elements@2.0.1:
+    resolution: {integrity: sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==}
+    dev: false
+
   /html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+    dev: false
+
+  /htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
+    dev: false
+
+  /humps@2.0.1:
+    resolution: {integrity: sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==}
     dev: false
 
   /iconv-lite@0.6.3:
@@ -3422,7 +5643,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.2.0
-    dev: true
 
   /is-boolean-object@1.1.2:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
@@ -3467,7 +5687,6 @@ packages:
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /is-finalizationregistry@1.0.2:
     resolution: {integrity: sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==}
@@ -3487,7 +5706,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
-    dev: true
 
   /is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
@@ -3512,7 +5730,6 @@ packages:
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-    dev: true
 
   /is-obj@3.0.0:
     resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
@@ -3601,6 +5818,11 @@ packages:
       get-intrinsic: 1.2.2
     dev: true
 
+  /is-what@4.1.16:
+    resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
+    engines: {node: '>=12.13'}
+    dev: false
+
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
     dev: true
@@ -3618,10 +5840,13 @@ packages:
       set-function-name: 2.0.1
     dev: true
 
+  /javascript-stringify@2.1.0:
+    resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
+    dev: false
+
   /jiti@1.21.0:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
     hasBin: true
-    dev: true
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3655,6 +5880,14 @@ packages:
 
   /jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+    dev: false
+
+  /jsonfile@6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
     dev: false
 
   /jsx-ast-utils@3.3.5:
@@ -3715,6 +5948,10 @@ packages:
       type-check: 0.4.0
     dev: true
 
+  /lil-fp@1.4.5:
+    resolution: {integrity: sha512-RrMQ2dB7SDXriFPZMMHEmroaSP6lFw3QEV7FOfSkf19kvJnDzHqKMc2P9HOf5uE8fOp5YxodSrq7XxWjdeC2sw==}
+    dev: false
+
   /lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
@@ -3724,20 +5961,47 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
 
+  /load-yaml-file@0.2.0:
+    resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
+    engines: {node: '>=6'}
+    dependencies:
+      graceful-fs: 4.2.11
+      js-yaml: 3.14.1
+      pify: 4.0.1
+      strip-bom: 3.0.0
+    dev: false
+
+  /locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-locate: 4.1.0
+    dev: false
+
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
     dependencies:
       p-locate: 5.0.0
-    dev: true
 
   /lodash-es@4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
     dev: false
 
+  /lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    dev: false
+
+  /lodash.memoize@4.1.2:
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+    dev: false
+
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-    dev: true
+
+  /lodash.uniq@4.5.0:
+    resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
+    dev: false
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -3745,6 +6009,10 @@ packages:
 
   /longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+    dev: false
+
+  /look-it-up@2.1.0:
+    resolution: {integrity: sha512-nMoGWW2HurtuJf6XAL56FWTDCWLOTSsanrgwOyaR5Y4e3zfG5N/0cU5xWZSEU3tBxhQugRbV1xL9jb+ug7yZww==}
     dev: false
 
   /loose-envify@1.4.0:
@@ -3771,6 +6039,13 @@ packages:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
     dev: false
 
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: false
+
   /markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
@@ -3793,6 +6068,14 @@ packages:
       mhchemparser: 4.2.1
       mj-context-menu: 0.6.1
       speech-rule-engine: 4.0.7
+    dev: false
+
+  /mdast-util-definitions@5.1.2:
+    resolution: {integrity: sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==}
+    dependencies:
+      '@types/mdast': 3.0.15
+      '@types/unist': 2.0.10
+      unist-util-visit: 4.1.2
     dev: false
 
   /mdast-util-find-and-replace@3.0.1:
@@ -4003,6 +6286,19 @@ packages:
       unist-util-is: 6.0.0
     dev: false
 
+  /mdast-util-to-hast@12.3.0:
+    resolution: {integrity: sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==}
+    dependencies:
+      '@types/hast': 2.3.8
+      '@types/mdast': 3.0.15
+      mdast-util-definitions: 5.1.2
+      micromark-util-sanitize-uri: 1.2.0
+      trim-lines: 3.0.1
+      unist-util-generated: 2.0.1
+      unist-util-position: 4.0.4
+      unist-util-visit: 4.1.2
+    dev: false
+
   /mdast-util-to-hast@13.0.2:
     resolution: {integrity: sha512-U5I+500EOOw9e3ZrclN3Is3fRpw8c19SMyNZlZ2IS+7vLsNzb2Om11VpIVOR+/0137GhZsFEF6YiKD5+0Hr2Og==}
     dependencies:
@@ -4041,10 +6337,16 @@ packages:
       '@types/mdast': 4.0.3
     dev: false
 
+  /merge-anything@5.1.7:
+    resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
+    engines: {node: '>=12.13'}
+    dependencies:
+      is-what: 4.1.16
+    dev: false
+
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-    dev: true
 
   /mermaid@10.6.1:
     resolution: {integrity: sha512-Hky0/RpOw/1il9X8AvzOEChfJtVvmXm+y7JML5C//ePYMy0/9jCEmW1E1g86x9oDfW9+iVEdTV/i+M6KWRNs4A==}
@@ -4075,6 +6377,10 @@ packages:
 
   /mhchemparser@4.2.1:
     resolution: {integrity: sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==}
+    dev: false
+
+  /microdiff@1.3.2:
+    resolution: {integrity: sha512-pKy60S2febliZIbwdfEQKTtL5bLNxOyiRRmD400gueYl9XcHyNGxzHSlJWn9IMHwYXT0yohPYL08+bGozVk8cQ==}
     dev: false
 
   /micromark-core-commonmark@1.1.0:
@@ -4613,13 +6919,19 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
-    dev: true
 
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
     dev: true
+
+  /minimatch@7.4.6:
+    resolution: {integrity: sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
 
   /minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
@@ -4629,6 +6941,21 @@ packages:
 
   /mj-context-menu@0.6.1:
     resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
+    dev: false
+
+  /mkdirp@2.1.6:
+    resolution: {integrity: sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: false
+
+  /mlly@1.5.0:
+    resolution: {integrity: sha512-NPVQvAY1xr1QoVeG0cy8yUYC7FQcOx6evl/RjT1wL5FvzPnzOysoqB/jmx/DhssT2dYa8nxECLAaFI/+gVLhDQ==}
+    dependencies:
+      acorn: 8.11.3
+      pathe: 1.1.2
+      pkg-types: 1.0.3
+      ufo: 1.3.2
     dev: false
 
   /mri@1.2.0:
@@ -4786,9 +7113,19 @@ packages:
       '@types/nlcst': 1.0.4
     dev: false
 
+  /node-eval@2.0.0:
+    resolution: {integrity: sha512-Ap+L9HznXAVeJj3TJ1op6M6bg5xtTq8L5CU/PJxtkhea/DrIxdTknGKIECKd/v/Lgql95iuMAYvIzBNd0pmcMg==}
+    engines: {node: '>= 4'}
+    dependencies:
+      path-is-absolute: 1.0.1
+    dev: false
+
   /node-releases@2.0.13:
     resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
-    dev: true
+
+  /node-releases@2.0.14:
+    resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
+    dev: false
 
   /non-layered-tidy-tree-layout@2.0.2:
     resolution: {integrity: sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==}
@@ -4797,12 +7134,10 @@ packages:
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /npm-run-path@2.0.2:
     resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
@@ -4819,7 +7154,6 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
@@ -4834,6 +7168,11 @@ packages:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
     dev: true
+
+  /object-path@0.11.8:
+    resolution: {integrity: sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==}
+    engines: {node: '>= 10.12.0'}
+    dev: false
 
   /object.assign@4.1.5:
     resolution: {integrity: sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==}
@@ -4885,6 +7224,15 @@ packages:
       wrappy: 1.0.2
     dev: true
 
+  /optimism@0.18.0:
+    resolution: {integrity: sha512-tGn8+REwLRNFnb9WmcY5IfpOqeX2kpaYJ1s6Ae3mn12AeydLkR3j+jSCmVQFoXqU8D41PAJ1RG1rCRNWmNZVmQ==}
+    dependencies:
+      '@wry/caches': 1.0.1
+      '@wry/context': 0.7.4
+      '@wry/trie': 0.4.3
+      tslib: 2.6.2
+    dev: false
+
   /optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
@@ -4897,9 +7245,20 @@ packages:
       type-check: 0.4.0
     dev: true
 
+  /outdent@0.8.0:
+    resolution: {integrity: sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==}
+    dev: false
+
   /p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
+    dev: false
+
+  /p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+    dependencies:
+      p-try: 2.2.0
     dev: false
 
   /p-limit@3.1.0:
@@ -4907,7 +7266,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
-    dev: true
 
   /p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
@@ -4916,12 +7274,23 @@ packages:
       yocto-queue: 1.0.0
     dev: false
 
+  /p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-limit: 2.3.0
+    dev: false
+
   /p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
     dependencies:
       p-limit: 3.1.0
-    dev: true
+
+  /p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+    dev: false
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -4955,21 +7324,27 @@ packages:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
     dev: false
 
+  /parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+    dev: false
+
   /parse5@7.1.2:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
     dependencies:
       entities: 4.5.0
     dev: false
 
+  /path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+    dev: false
+
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /path-key@2.0.1:
     resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
@@ -4990,6 +7365,18 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /pathe@1.1.1:
+    resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
+    dev: false
+
+  /pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+    dev: false
+
+  /perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+    dev: false
+
   /periscopic@3.1.0:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
     dependencies:
@@ -5004,17 +7391,59 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-    dev: true
 
   /pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /pify@4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
+    dev: false
+
   /pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
     dev: true
+
+  /pkg-dir@4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      find-up: 4.1.0
+    dev: false
+
+  /pkg-types@1.0.3:
+    resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
+    dependencies:
+      jsonc-parser: 3.2.0
+      mlly: 1.5.0
+      pathe: 1.1.1
+    dev: false
+
+  /pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /postcss-discard-duplicates@6.0.1(postcss@8.4.31):
+    resolution: {integrity: sha512-1hvUs76HLYR8zkScbwyJ8oJEugfPV+WchpnA+26fpJ7Smzs51CzGBHC32RS03psuX/2l0l0UKh2StzNxOrKCYg==}
+    engines: {node: ^14 || ^16 || >=18.0}
+    peerDependencies:
+      postcss: ^8.4.31
+    dependencies:
+      postcss: 8.4.31
+    dev: false
+
+  /postcss-discard-empty@6.0.1(postcss@8.4.31):
+    resolution: {integrity: sha512-yitcmKwmVWtNsrrRqGJ7/C0YRy53i0mjexBDQ9zYxDwTWVBgbU4+C9jIZLmQlTDT9zhml+u0OMFJh8+31krmOg==}
+    engines: {node: ^14 || ^16 || >=18.0}
+    peerDependencies:
+      postcss: ^8.4.31
+    dependencies:
+      postcss: 8.4.31
+    dev: false
 
   /postcss-import@15.1.0(postcss@8.4.31):
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -5055,6 +7484,29 @@ packages:
       yaml: 2.3.4
     dev: true
 
+  /postcss-merge-rules@6.0.3(postcss@8.4.31):
+    resolution: {integrity: sha512-yfkDqSHGohy8sGYIJwBmIGDv4K4/WrJPX355XrxQb/CSsT4Kc/RxDi6akqn5s9bap85AWgv21ArcUWwWdGNSHA==}
+    engines: {node: ^14 || ^16 || >=18.0}
+    peerDependencies:
+      postcss: ^8.4.31
+    dependencies:
+      browserslist: 4.22.3
+      caniuse-api: 3.0.0
+      cssnano-utils: 4.0.1(postcss@8.4.31)
+      postcss: 8.4.31
+      postcss-selector-parser: 6.0.15
+    dev: false
+
+  /postcss-minify-selectors@6.0.2(postcss@8.4.31):
+    resolution: {integrity: sha512-0b+m+w7OAvZejPQdN2GjsXLv5o0jqYHX3aoV0e7RBKPCsB7TYG5KKWBFhGnB/iP3213Ts8c5H4wLPLMm7z28Sg==}
+    engines: {node: ^14 || ^16 || >=18.0}
+    peerDependencies:
+      postcss: ^8.4.31
+    dependencies:
+      postcss: 8.4.31
+      postcss-selector-parser: 6.0.15
+    dev: false
+
   /postcss-nested@6.0.1(postcss@8.4.31):
     resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
     engines: {node: '>=12.0'}
@@ -5063,7 +7515,16 @@ packages:
     dependencies:
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
-    dev: true
+
+  /postcss-normalize-whitespace@6.0.1(postcss@8.4.31):
+    resolution: {integrity: sha512-76i3NpWf6bB8UHlVuLRxG4zW2YykF9CTEcq/9LGAiz2qBuX5cBStadkk0jSkg9a9TCIXbMQz7yzrygKoCW9JuA==}
+    engines: {node: ^14 || ^16 || >=18.0}
+    peerDependencies:
+      postcss: ^8.4.31
+    dependencies:
+      postcss: 8.4.31
+      postcss-value-parser: 4.2.0
+    dev: false
 
   /postcss-selector-parser@6.0.13:
     resolution: {integrity: sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==}
@@ -5071,7 +7532,14 @@ packages:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-    dev: true
+
+  /postcss-selector-parser@6.0.15:
+    resolution: {integrity: sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==}
+    engines: {node: '>=4'}
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+    dev: false
 
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -5084,10 +7552,50 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
+  /postcss@8.4.33:
+    resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: false
+
+  /preferred-pm@3.1.2:
+    resolution: {integrity: sha512-nk7dKrcW8hfCZ4H6klWcdRknBOXWzNQByJ0oJyX97BOupsYD+FzLS4hflgEu/uPUEHZCuRfMxzCBsuWd7OzT8Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      find-up: 5.0.0
+      find-yarn-workspace-root2: 1.2.16
+      path-exists: 4.0.0
+      which-pm: 2.0.0
+    dev: false
+
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
     dev: true
+
+  /prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: false
+
+  /prism-react-renderer@2.3.1(react@18.2.0):
+    resolution: {integrity: sha512-Rdf+HzBLR7KYjzpJ1rSoxT9ioO85nZngQEoFIhL07XhtJHlCU3SOz0GJ6+qvMyQe0Se+BV3qpe6Yd/NmQF5Juw==}
+    peerDependencies:
+      react: '>=16.0.0'
+    dependencies:
+      '@types/prismjs': 1.26.3
+      clsx: 2.0.0
+      react: 18.2.0
+    dev: false
+
+  /prismjs@1.29.0:
+    resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
+    engines: {node: '>=6'}
+    dev: false
 
   /prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -5095,7 +7603,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: true
 
   /property-information@6.4.0:
     resolution: {integrity: sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ==}
@@ -5116,7 +7623,6 @@ packages:
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-    dev: true
 
   /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
@@ -5126,6 +7632,15 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+    dev: false
+
+  /react-error-boundary@4.0.12(react@18.2.0):
+    resolution: {integrity: sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.23.2
+      react: 18.2.0
     dev: false
 
   /react-fast-marquee@1.6.2(react-dom@18.2.0)(react@18.2.0):
@@ -5138,9 +7653,57 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /react-hotkeys-hook@4.4.4(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-wzZmqb/Obr0ds9Myc1sIFPJ52GA/Eeg/vXBWV0HA1LvHlVAW5Va3KB0q6EZNlNSHQWscWZ2K8+6w0GYSie2o7A==}
+    peerDependencies:
+      react: '>=16.8.1'
+      react-dom: '>=16.8.1'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /react-icons@4.12.0(react@18.2.0):
+    resolution: {integrity: sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==}
+    peerDependencies:
+      react: '*'
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-    dev: true
+
+  /react-is@18.2.0:
+    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+    dev: false
+
+  /react-markdown@8.0.7(@types/react@18.2.46)(react@18.2.0):
+    resolution: {integrity: sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+    dependencies:
+      '@types/hast': 2.3.8
+      '@types/prop-types': 15.7.10
+      '@types/react': 18.2.46
+      '@types/unist': 2.0.10
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 2.0.1
+      prop-types: 15.8.1
+      property-information: 6.4.0
+      react: 18.2.0
+      react-is: 18.2.0
+      remark-parse: 10.0.2
+      remark-rehype: 10.1.0
+      space-separated-tokens: 2.0.2
+      style-to-object: 0.4.4
+      unified: 10.1.2
+      unist-util-visit: 4.1.2
+      vfile: 5.3.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /react-marquee-slider@1.1.5(styled-components@6.1.8):
     resolution: {integrity: sha512-eta0DSKMu8F+82O3zF4jlWdTTlsmJg3h8n12trqCndBYo5DAc07odVlfxSfSsEGcBEHYli12RehrK3EYc4LwrQ==}
@@ -5148,6 +7711,37 @@ packages:
       styled-components: '>=4.0.0'
     dependencies:
       styled-components: 6.1.8(react-dom@18.2.0)(react@18.2.0)
+    dev: false
+
+  /react-property@2.0.0:
+    resolution: {integrity: sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==}
+    dev: false
+
+  /react-shadow@20.4.0(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-sirvAmFja7Ss6MoyQbKWxaQ5IDTAW3Za3Tvegylfr5jXnwKZObHRIyiatefeNlskoGKfuPaZ8DNT052T0SUGcg==}
+    peerDependencies:
+      prop-types: ^15.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      humps: 2.0.1
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /react-textarea-autosize@8.5.3(@types/react@18.2.46)(react@18.2.0):
+    resolution: {integrity: sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.23.2
+      react: 18.2.0
+      use-composed-ref: 1.3.0(react@18.2.0)
+      use-latest: 1.2.1(@types/react@18.2.46)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
     dev: false
 
   /react@18.2.0:
@@ -5168,7 +7762,6 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
-    dev: true
 
   /reading-time@1.5.0:
     resolution: {integrity: sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==}
@@ -5223,6 +7816,14 @@ packages:
       shiki: /shikiji@0.6.10
     dev: false
 
+  /rehype-raw@6.1.1:
+    resolution: {integrity: sha512-d6AKtisSRtDRX4aSPsJGTfnzrX2ZkHQLE5kiUuGOeEoLpbEulFF4hj0mLPbsa+7vmguDKOVVEQdHKDSwoaIDsQ==}
+    dependencies:
+      '@types/hast': 2.3.8
+      hast-util-raw: 7.2.3
+      unified: 10.1.2
+    dev: false
+
   /rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
     dependencies:
@@ -5275,6 +7876,16 @@ packages:
       - supports-color
     dev: false
 
+  /remark-parse@10.0.2:
+    resolution: {integrity: sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==}
+    dependencies:
+      '@types/mdast': 3.0.15
+      mdast-util-from-markdown: 1.3.1
+      unified: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
     dependencies:
@@ -5293,6 +7904,15 @@ packages:
       estree-util-value-to-estree: 1.3.0
       reading-time: 1.5.0
       unist-util-visit: 3.1.0
+    dev: false
+
+  /remark-rehype@10.1.0:
+    resolution: {integrity: sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==}
+    dependencies:
+      '@types/hast': 2.3.8
+      '@types/mdast': 3.0.15
+      mdast-util-to-hast: 12.3.0
+      unified: 10.1.2
     dev: false
 
   /remark-rehype@11.0.0:
@@ -5345,6 +7965,11 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
+  /response-iterator@0.2.6:
+    resolution: {integrity: sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==}
+    engines: {node: '>=0.8'}
+    dev: false
+
   /retext-latin@3.1.0:
     resolution: {integrity: sha512-5MrD1tuebzO8ppsja5eEu+ZbBeUNCjoEarn70tkXOS7Bdsdf6tNahsv2bY0Z8VooFF6cw7/6S+d3yI/TMlMVVQ==}
     dependencies:
@@ -5383,7 +8008,6 @@ packages:
   /reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-    dev: true
 
   /rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -5400,7 +8024,6 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
-    dev: true
 
   /rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
@@ -5560,6 +8183,10 @@ packages:
     requiresBuild: true
     dev: true
 
+  /sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+    dev: false
+
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -5666,6 +8293,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+    dev: false
+
   /strip-eof@1.0.0:
     resolution: {integrity: sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==}
     engines: {node: '>=0.10.0'}
@@ -5675,6 +8307,18 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
     dev: true
+
+  /style-to-js@1.1.3:
+    resolution: {integrity: sha512-zKI5gN/zb7LS/Vm0eUwjmjrXWw8IMtyA8aPBJZdYiQTXj4+wQ3IucOLIOnF7zCHxvW8UhIGh/uZh/t9zEHXNTQ==}
+    dependencies:
+      style-to-object: 0.4.1
+    dev: false
+
+  /style-to-object@0.4.1:
+    resolution: {integrity: sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==}
+    dependencies:
+      inline-style-parser: 0.1.1
+    dev: false
 
   /style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
@@ -5766,6 +8410,11 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /symbol-observable@4.0.0:
+    resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
+    engines: {node: '>=0.10'}
+    dev: false
+
   /tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
     dev: false
@@ -5837,12 +8486,16 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /to-fast-properties@2.0.0:
+    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
+    engines: {node: '>=4'}
+    dev: false
+
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
-    dev: true
 
   /trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -5866,9 +8519,56 @@ packages:
     engines: {node: '>=6.10'}
     dev: false
 
+  /ts-evaluator@1.2.0(typescript@5.2.2):
+    resolution: {integrity: sha512-ncSGek1p92bj2ifB7s9UBgryHCkU9vwC5d+Lplt12gT9DH+e41X8dMoHRQjIMeAvyG7j9dEnuHmwgOtuRIQL+Q==}
+    engines: {node: '>=14.19.0'}
+    peerDependencies:
+      jsdom: '>=14.x || >=15.x || >=16.x || >=17.x || >=18.x || >=19.x || >=20.x || >=21.x || >=22.x'
+      typescript: '>=3.2.x || >= 4.x || >= 5.x'
+    peerDependenciesMeta:
+      jsdom:
+        optional: true
+    dependencies:
+      ansi-colors: 4.1.3
+      crosspath: 2.0.0
+      object-path: 0.11.8
+      typescript: 5.2.2
+    dev: false
+
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
+
+  /ts-invariant@0.10.3:
+    resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /ts-morph@19.0.0:
+    resolution: {integrity: sha512-D6qcpiJdn46tUqV45vr5UGM2dnIEuTGNxVhg0sk5NX11orcouwj6i1bMqZIz2mZTZB1Hcgy7C3oEVhAT+f6mbQ==}
+    dependencies:
+      '@ts-morph/common': 0.20.0
+      code-block-writer: 12.0.0
+    dev: false
+
+  /ts-pattern@5.0.5:
+    resolution: {integrity: sha512-tL0w8U/pgaacOmkb9fRlYzWEUDCfVjjv9dD4wHTgZ61MjhuMt46VNWTG747NqW6vRzoWIKABVhFSOJ82FvXrfA==}
+    dev: false
+
+  /tsconfck@2.1.2(typescript@5.2.2):
+    resolution: {integrity: sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==}
+    engines: {node: ^14.13.1 || ^16 || >=18}
+    hasBin: true
+    peerDependencies:
+      typescript: ^4.3.5 || ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.2.2
+    dev: false
 
   /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
@@ -5960,6 +8660,16 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: false
+
+  /ufo@1.3.2:
+    resolution: {integrity: sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==}
+    dev: false
+
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
@@ -6008,6 +8718,10 @@ packages:
       unist-util-is: 6.0.0
     dev: false
 
+  /unist-util-generated@2.0.1:
+    resolution: {integrity: sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==}
+    dev: false
+
   /unist-util-is@5.2.1:
     resolution: {integrity: sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==}
     dependencies:
@@ -6031,6 +8745,12 @@ packages:
     resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
     dependencies:
       '@types/unist': 3.0.2
+    dev: false
+
+  /unist-util-position@4.0.4:
+    resolution: {integrity: sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==}
+    dependencies:
+      '@types/unist': 2.0.10
     dev: false
 
   /unist-util-position@5.0.0:
@@ -6117,6 +8837,11 @@ packages:
       unist-util-visit-parents: 6.0.1
     dev: false
 
+  /universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+    dev: false
+
   /update-browserslist-db@1.0.13(browserslist@4.22.1):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
@@ -6126,7 +8851,17 @@ packages:
       browserslist: 4.22.1
       escalade: 3.1.1
       picocolors: 1.0.0
-    dev: true
+
+  /update-browserslist-db@1.0.13(browserslist@4.22.3):
+    resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.22.3
+      escalade: 3.1.1
+      picocolors: 1.0.0
+    dev: false
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -6134,9 +8869,43 @@ packages:
       punycode: 2.3.1
     dev: true
 
+  /use-composed-ref@1.3.0(react@18.2.0):
+    resolution: {integrity: sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
+
+  /use-isomorphic-layout-effect@1.1.2(@types/react@18.2.46)(react@18.2.0):
+    resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.46
+      react: 18.2.0
+    dev: false
+
+  /use-latest@1.2.1(@types/react@18.2.46)(react@18.2.0):
+    resolution: {integrity: sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.46
+      react: 18.2.0
+      use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.46)(react@18.2.0)
+    dev: false
+
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-    dev: true
 
   /uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -6152,6 +8921,13 @@ packages:
       diff: 5.1.0
       kleur: 4.1.5
       sade: 1.8.1
+    dev: false
+
+  /vfile-location@4.1.0:
+    resolution: {integrity: sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==}
+    dependencies:
+      '@types/unist': 2.0.10
+      vfile: 5.3.7
     dev: false
 
   /vfile-location@5.0.2:
@@ -6253,6 +9029,14 @@ packages:
       is-weakset: 2.0.2
     dev: true
 
+  /which-pm@2.0.0:
+    resolution: {integrity: sha512-Lhs9Pmyph0p5n5Z3mVnN0yWcbQYUAD7rbQUiMsQxOJ3T57k7RFe35SUwWMf7dsbDZks1uOmw4AecB/JMDj3v/w==}
+    engines: {node: '>=8.15'}
+    dependencies:
+      load-yaml-file: 0.2.0
+      path-exists: 4.0.0
+    dev: false
+
   /which-typed-array@1.1.13:
     resolution: {integrity: sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==}
     engines: {node: '>= 0.4'}
@@ -6292,6 +9076,12 @@ packages:
     engines: {node: '>=0.1'}
     dev: false
 
+  /xregexp@5.1.1:
+    resolution: {integrity: sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==}
+    dependencies:
+      '@babel/runtime-corejs3': 7.23.9
+    dev: false
+
   /yallist@2.1.2:
     resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
     dev: false
@@ -6307,11 +9097,20 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-    dev: true
 
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+    dev: false
+
+  /zen-observable-ts@1.2.5:
+    resolution: {integrity: sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==}
+    dependencies:
+      zen-observable: 0.8.15
+    dev: false
+
+  /zen-observable@0.8.15:
+    resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
     dev: false
 
   /zod-validation-error@1.5.0(zod@3.22.4):

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -43,7 +43,7 @@ const config: DocsThemeConfig = {
         <div className="relative">
           <Link
             className="p-2"
-            href="https://github.com/next-auth/nextauthjs"
+            href="https://github.com/nextauthjs/next-auth"
             target="_blank"
           >
             <svg

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -2,6 +2,15 @@ import { DocsThemeConfig } from "nextra-theme-docs";
 import { Link } from "@/components/Link";
 import { ChildrenProps } from "@/utils/types";
 import Footer from "@/components/Footer";
+import dynamic from "next/dynamic";
+
+const InkeepChatButton = dynamic(
+  () => import("@/components/InkeepSearch").then((mod) => mod.InkeepTrigger),
+  {
+    ssr: false,
+    // loading: () => <div>loading...</div>, // optional: loading animation component
+  }
+);
 
 const config: DocsThemeConfig = {
   logo: (
@@ -29,8 +38,28 @@ const config: DocsThemeConfig = {
   },
   navbar: {
     extraContent: (
-      <div className="relative">
-        <div className="github-counter">20k</div>
+      <div className="flex gap-4 items-center !h-12">
+        <InkeepChatButton />
+        <div className="relative">
+          <Link
+            className="p-2"
+            href="https://github.com/next-auth/nextauthjs"
+            target="_blank"
+          >
+            <svg
+              className="size-4"
+              width="24"
+              height="24"
+              fill="currentColor"
+              viewBox="3 3 18 18"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>GitHub</title>
+              <path d="M12 3C7.0275 3 3 7.12937 3 12.2276C3 16.3109 5.57625 19.7597 9.15374 20.9824C9.60374 21.0631 9.77249 20.7863 9.77249 20.5441C9.77249 20.3249 9.76125 19.5982 9.76125 18.8254C7.5 19.2522 6.915 18.2602 6.735 17.7412C6.63375 17.4759 6.19499 16.6569 5.8125 16.4378C5.4975 16.2647 5.0475 15.838 5.80124 15.8264C6.51 15.8149 7.01625 16.4954 7.18499 16.7723C7.99499 18.1679 9.28875 17.7758 9.80625 17.5335C9.885 16.9337 10.1212 16.53 10.38 16.2993C8.3775 16.0687 6.285 15.2728 6.285 11.7432C6.285 10.7397 6.63375 9.9092 7.20749 9.26326C7.1175 9.03257 6.8025 8.08674 7.2975 6.81794C7.2975 6.81794 8.05125 6.57571 9.77249 7.76377C10.4925 7.55615 11.2575 7.45234 12.0225 7.45234C12.7875 7.45234 13.5525 7.55615 14.2725 7.76377C15.9937 6.56418 16.7475 6.81794 16.7475 6.81794C17.2424 8.08674 16.9275 9.03257 16.8375 9.26326C17.4113 9.9092 17.76 10.7281 17.76 11.7432C17.76 15.2843 15.6563 16.0687 13.6537 16.2993C13.98 16.5877 14.2613 17.1414 14.2613 18.0065C14.2613 19.2407 14.25 20.2326 14.25 20.5441C14.25 20.7863 14.4188 21.0746 14.8688 20.9824C16.6554 20.364 18.2079 19.1866 19.3078 17.6162C20.4077 16.0457 20.9995 14.1611 21 12.2276C21 7.12937 16.9725 3 12 3Z"></path>
+            </svg>
+          </Link>
+          <div className="github-counter">20k</div>
+        </div>
       </div>
     ),
   },

--- a/utils/useInkeepSettings.ts
+++ b/utils/useInkeepSettings.ts
@@ -1,6 +1,5 @@
 import type {
   InkeepAIChatSettings,
-  InkeepSearchSettings,
   InkeepWidgetBaseSettings,
   InkeepModalSettings,
 } from "@inkeep/widgets";
@@ -9,7 +8,6 @@ import { useTheme } from "nextra-theme-docs";
 type InkeepSharedSettings = {
   baseSettings: InkeepWidgetBaseSettings;
   aiChatSettings: InkeepAIChatSettings;
-  searchSettings: InkeepSearchSettings;
   modalSettings: InkeepModalSettings;
 };
 
@@ -29,15 +27,10 @@ const useInkeepSettings = (): InkeepSharedSettings => {
   };
 
   const modalSettings: InkeepModalSettings = {
-    // optional settings
-  };
-
-  const searchSettings: InkeepSearchSettings = {
-    // optional settings
+    defaultView: "AI_CHAT",
   };
 
   const aiChatSettings: InkeepAIChatSettings = {
-    // optional settings
     botAvatarSrcUrl: "/img/etc/logo-sm.webp",
     quickQuestions: [
       "Example question 1?",
@@ -46,7 +39,7 @@ const useInkeepSettings = (): InkeepSharedSettings => {
     ],
   };
 
-  return { baseSettings, aiChatSettings, searchSettings, modalSettings };
+  return { baseSettings, aiChatSettings, modalSettings };
 };
 
 export default useInkeepSettings;

--- a/utils/useInkeepSettings.ts
+++ b/utils/useInkeepSettings.ts
@@ -2,6 +2,7 @@ import type {
   InkeepAIChatSettings,
   InkeepWidgetBaseSettings,
   InkeepModalSettings,
+  AIChatDisclaimerSettings,
 } from "@inkeep/widgets";
 import { useTheme } from "nextra-theme-docs";
 
@@ -31,6 +32,13 @@ const useInkeepSettings = (): InkeepSharedSettings => {
     switchToChatMessage: "Switch to chat",
   };
 
+  const disclaimerSettings: AIChatDisclaimerSettings = {
+    isDisclaimerEnabled: true,
+    disclaimerLabel: "Usage policy",
+    disclaimerTooltip:
+      "Your data is <b>never used to train the underlying LLM models</b>. Information provided by this AI assistant is <b>not guaranteed to be accurate or comprehensive</b>. Please consult Auth.js's documentation and GitHub repository for <b>authoritative results</b>. More information about how this data is used can be found in InKeep's <a href='https://docs.inkeep.com/overview/privacy'>privacy page</a>.",
+  };
+
   const aiChatSettings: InkeepAIChatSettings = {
     botAvatarSrcUrl: "/img/etc/logo-sm.webp",
     quickQuestions: [
@@ -38,6 +46,7 @@ const useInkeepSettings = (): InkeepSharedSettings => {
       "How do I save extra fields from a provider's user profile response?",
       "How do I access the session object in SvelteKit?",
     ],
+    disclaimerSettings,
   };
 
   return { baseSettings, aiChatSettings, modalSettings };

--- a/utils/useInkeepSettings.ts
+++ b/utils/useInkeepSettings.ts
@@ -16,9 +16,9 @@ type InkeepSharedSettings = {
 const useInkeepSettings = (): InkeepSharedSettings => {
   const { resolvedTheme } = useTheme();
   const baseSettings: InkeepWidgetBaseSettings = {
-    apiKey: process.env.INKEEP_API_KEY,
-    integrationId: process.env.INKEEP_INTEGRATION_ID,
-    organizationId: process.env.INKKEEP_ORGANIZATION_ID,
+    apiKey: process.env.NEXT_PUBLIC_INKEEP_API_KEY,
+    integrationId: process.env.NEXT_PUBLIC_INKEEP_INTEGRATION_ID,
+    organizationId: process.env.NEXT_PUBLIC_INKEEP_ORGANIZATION_ID,
     primaryBrandColor: "#efe0ff", // your brand color, widget color scheme is derived from this
     organizationDisplayName: "Auth.js",
     theme: {

--- a/utils/useInkeepSettings.ts
+++ b/utils/useInkeepSettings.ts
@@ -34,9 +34,9 @@ const useInkeepSettings = (): InkeepSharedSettings => {
   const aiChatSettings: InkeepAIChatSettings = {
     botAvatarSrcUrl: "/img/etc/logo-sm.webp",
     quickQuestions: [
-      "Example question 1?",
-      "Example question 2?",
-      "Example question 3?",
+      "How do I migrate my Next.js app from v4 to v5?",
+      "How do I save extra fields from a provider's user profile response?",
+      "How do I access the session object in SvelteKit?",
     ],
   };
 

--- a/utils/useInkeepSettings.ts
+++ b/utils/useInkeepSettings.ts
@@ -36,7 +36,7 @@ const useInkeepSettings = (): InkeepSharedSettings => {
     isDisclaimerEnabled: true,
     disclaimerLabel: "Usage policy",
     disclaimerTooltip:
-      "Your data is <b>never used to train the underlying LLM models</b>. Information provided by this AI assistant is <b>not guaranteed to be accurate or comprehensive</b>. Please consult Auth.js's documentation and GitHub repository for <b>authoritative results</b>. More information about how this data is used can be found in InKeep's <a href='https://docs.inkeep.com/overview/privacy'>privacy page</a>.",
+      "Your data is <b>never used to train the underlying LLM models</b>. Information provided by this AI assistant is <b>not guaranteed to be accurate or comprehensive</b>. Please consult Auth.js's documentation and GitHub repository for <b>authoritative results</b> if you are unsure. More information about how this data is used can be found in InKeep's <a href='https://docs.inkeep.com/overview/privacy'>privacy page</a>.",
   };
 
   const aiChatSettings: InkeepAIChatSettings = {

--- a/utils/useInkeepSettings.ts
+++ b/utils/useInkeepSettings.ts
@@ -28,6 +28,7 @@ const useInkeepSettings = (): InkeepSharedSettings => {
 
   const modalSettings: InkeepModalSettings = {
     defaultView: "AI_CHAT",
+    switchToChatMessage: "Switch to chat",
   };
 
   const aiChatSettings: InkeepAIChatSettings = {

--- a/utils/useInkeepSettings.ts
+++ b/utils/useInkeepSettings.ts
@@ -1,0 +1,52 @@
+import type {
+  InkeepAIChatSettings,
+  InkeepSearchSettings,
+  InkeepWidgetBaseSettings,
+  InkeepModalSettings,
+} from "@inkeep/widgets";
+import { useTheme } from "nextra-theme-docs";
+
+type InkeepSharedSettings = {
+  baseSettings: InkeepWidgetBaseSettings;
+  aiChatSettings: InkeepAIChatSettings;
+  searchSettings: InkeepSearchSettings;
+  modalSettings: InkeepModalSettings;
+};
+
+const useInkeepSettings = (): InkeepSharedSettings => {
+  const { resolvedTheme } = useTheme();
+  const baseSettings: InkeepWidgetBaseSettings = {
+    apiKey: process.env.INKEEP_API_KEY,
+    integrationId: process.env.INKEEP_INTEGRATION_ID,
+    organizationId: process.env.INKKEEP_ORGANIZATION_ID,
+    primaryBrandColor: "#efe0ff", // your brand color, widget color scheme is derived from this
+    organizationDisplayName: "Auth.js",
+    theme: {
+      colorMode: {
+        forcedColorMode: resolvedTheme, // to sync dark mode with the widget
+      },
+    },
+  };
+
+  const modalSettings: InkeepModalSettings = {
+    // optional settings
+  };
+
+  const searchSettings: InkeepSearchSettings = {
+    // optional settings
+  };
+
+  const aiChatSettings: InkeepAIChatSettings = {
+    // optional settings
+    botAvatarSrcUrl: "/img/etc/logo-sm.webp",
+    quickQuestions: [
+      "Example question 1?",
+      "Example question 2?",
+      "Example question 3?",
+    ],
+  };
+
+  return { baseSettings, aiChatSettings, searchSettings, modalSettings };
+};
+
+export default useInkeepSettings;


### PR DESCRIPTION
- Add [InKeep button](https://docs.inkeep.com/integrations/nextra/chat-button) in navbar
- Clicking on btn opens a modal which has 2 modes:
	- Search: which searches both docs and our github and surfaces relevant PRs/issues
	- Chat: your typical AI chat with the current "prod" nextra docs and our Github being the source documents
- Adds these 3 example questions:
	- "How do I migrate my Next.js app from v4 to v5?"
    - "How do I save extra fields from a provider's user profile response?"
    - "How do I access the session object in SvelteKit?"
